### PR TITLE
Lint OpenAPI Spec For Code Generation 

### DIFF
--- a/fern/api/definition/openapi.json
+++ b/fern/api/definition/openapi.json
@@ -467,7 +467,7 @@
           }
         ],
         "tags": [
-          "Identity Management"
+          "Identity"
         ],
         "x-request-name": "ListTeamInvitationsRequest"
       }
@@ -608,7 +608,7 @@
           }
         },
         "tags": [
-          "Internal Endpoints"
+          "Internal"
         ],
         "x-request-name": "ProxyAmplitudeEventRequest"
       }
@@ -616,7 +616,7 @@
     "/cluster-contexts": {
       "post": {
         "description": "???",
-        "operationId": "SubmitClusterContext",
+        "operationId": "submitClusterContext",
         "responses": {
           "200": {
             "content": {},
@@ -629,8 +629,7 @@
           }
         ],
         "tags": [
-          "Deprecated",
-          "Agent API"
+          "Cluster"
         ],
         "x-request-name": "SubmitClusterContextRequest"
       }
@@ -638,7 +637,7 @@
     "/clusters": {
       "get": {
         "description": "???",
-        "operationId": "ListClusters",
+        "operationId": "getAll",
         "responses": {
           "200": {
             "content": {
@@ -657,14 +656,13 @@
           }
         ],
         "tags": [
-          "Agent",
           "Cluster"
         ],
         "x-request-name": "ListClustersRequest"
       },
       "post": {
         "description": "???",
-        "operationId": "CreateCluster",
+        "operationId": "create",
         "requestBody": {
           "content": {
             "application/json": {
@@ -693,7 +691,7 @@
           }
         ],
         "tags": [
-          "Agent API"
+          "Cluster"
         ],
         "x-request-name": "CreateClusterRequest"
       }
@@ -701,7 +699,7 @@
     "/clusters/{clusterId}": {
       "delete": {
         "description": "???",
-        "operationId": "DeleteCluster",
+        "operationId": "delete",
         "parameters": [
           {
             "explode": false,
@@ -725,7 +723,7 @@
           }
         ],
         "tags": [
-          "Cluster Management"
+          "Cluster"
         ],
         "x-request-name": "DeleteClusterRequest"
       },
@@ -809,8 +807,7 @@
           }
         ],
         "tags": [
-          "Agent API",
-          "Cluster Management"
+          "Cluster"
         ],
         "x-request-name": "UpdateClusterRequest"
       }
@@ -849,7 +846,7 @@
           }
         ],
         "tags": [
-          "Scan Management"
+          "Cluster"
         ],
         "x-request-name": "ListClusterScansWithArsigsRequest"
       }
@@ -898,7 +895,7 @@
           }
         ],
         "tags": [
-          "Cluster Management"
+          "Cluster"
         ],
         "x-request-name": "DeactivateClusterRequest"
       }
@@ -906,7 +903,7 @@
     "/clusters/{clusterId}/lars": {
       "get": {
         "description": "???",
-        "operationId": "ListClusterScansWithLars",
+        "operationId": "getAllClusterScans",
         "parameters": [
           {
             "explode": false,
@@ -976,7 +973,7 @@
           }
         ],
         "tags": [
-          "LAR Status Management"
+          "LAR Status"
         ],
         "x-request-name": "ListLARsStatusRequest"
       }
@@ -1182,7 +1179,7 @@
           }
         ],
         "tags": [
-          "Agent"
+          "Scan"
         ],
         "x-request-name": "GetClusterRescanStateRequest"
       },
@@ -1229,7 +1226,7 @@
           }
         ],
         "tags": [
-          "Agent"
+          "Scan"
         ],
         "x-request-name": "RescanClusterRequest"
       }
@@ -1278,7 +1275,7 @@
           }
         ],
         "tags": [
-          "Agent"
+          "Scan"
         ],
         "x-request-name": "CreateClusterScanRequest"
       }
@@ -1331,6 +1328,7 @@
           }
         ],
         "tags": [
+          "Internal",
           "Deprecated"
         ],
         "x-request-name": "GetInsightsRequest"
@@ -1352,6 +1350,7 @@
           }
         ],
         "tags": [
+          "Internal",
           "Deprecated"
         ],
         "x-request-name": "GetInsightsPeriodsRequest"
@@ -1656,6 +1655,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Internal"],
         "x-request-name": "GetKbaRequest"
       }
     },
@@ -1902,6 +1902,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Internal"],
         "x-request-name": "GetQuickStartStateRequest"
       }
     },
@@ -1945,7 +1946,6 @@
           }
         ],
         "tags": [
-          "Deprecated",
           "Integration"
         ],
         "x-request-name": "GetResourceRequest"
@@ -1972,6 +1972,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Scan"],
         "x-request-name": "ListScansRequest"
       },
       "post": {
@@ -2004,6 +2005,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Scan"],
         "x-request-name": "CreateScanRequest"
       }
     },
@@ -2018,7 +2020,7 @@
           }
         },
         "tags": [
-          "Internal Endpoints"
+          "Internal"
         ],
         "x-request-name": "ProxySentryReportRequest"
       }
@@ -2294,6 +2296,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Internal"],
         "x-request-name": "ListAvailabilityRisksRequest"
       }
     },
@@ -2396,6 +2399,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Internal"],
         "x-request-name": "GetAvailabilityRisksSummaryRequest"
       }
     },
@@ -2601,6 +2605,7 @@
             "accessTokenAuth": []
           }
         ],
+        "tags": ["Internal"],
         "x-request-name": "GetAvailabilityRiskAffectedResourceRequest"
       }
     }

--- a/fern/api/definition/openapi.json
+++ b/fern/api/definition/openapi.json
@@ -1,3934 +1,4750 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "contact" : {
-      "name" : "Website",
-      "url" : "https://www.chkk.io"
+  "openapi": "3.0.1",
+  "info": {
+    "contact": {
+      "name": "Website",
+      "url": "https://www.chkk.io"
     },
-    "description" : "Chkk API for Kubernetes deployment and upgrade safety.",
-    "title" : "Chkk API v1.0",
-    "version" : "v1.0"
+    "description": "Chkk API for Kubernetes deployment and upgrade safety.",
+    "title": "Chkk API v1.0",
+    "version": "v1.0"
   },
-  "externalDocs" : {
-    "description" : "A detailed documentation of the Chkk API",
-    "url" : "https://docs.chkk.io"
+  "externalDocs": {
+    "description": "A detailed documentation of the Chkk API",
+    "url": "https://docs.chkk.io"
   },
-  "servers" : [ {
-    "description" : "Prod",
-    "url" : "https://api.chkk.dev/v1"
-  }, {
-    "description" : "Prod AWS US-West-2",
-    "url" : "https://api.us-west-2.aws.chkk.io/v1"
-  } ],
-  "tags" : [ {
-    "description" : "APIs for management of subscriptions",
-    "name" : "Subscription Management"
-  }, {
-    "description" : "APIs used internally by Chkk components and are not meant for external callers",
-    "name" : "Internal Endpoints"
-  }, {
-    "description" : "APIs used to manage users, organizations and other identity concepts in Chkk",
-    "name" : "Identity Management"
-  }, {
-    "description" : "API used by the Chkk Agent or Chkk Operator that runs inside the K8s cluster",
-    "name" : "Agent API"
-  }, {
-    "description" : "APIs used to manage LARs and their lifecycle",
-    "name" : "LAR Status Management"
-  }, {
-    "description" : "???",
-    "name" : "Cluster Management"
-  }, {
-    "description" : "???",
-    "name" : "Scan Management"
-  }, {
-    "description" : "APIs used to manage the integrations of Chkk with customer systems (e.g. ticketing)",
-    "name" : "Integration Management"
-  }, {
-    "description" : "APIs used by the systems integrated with Chkk - not for management of such integrations",
-    "name" : "Integration Data Plane"
-  }, {
-    "description" : "APIs that are not to be used for new features and we are working to phase out",
-    "name" : "Deprecated"
-  } ],
-  "paths" : {
-    "/accept/{invite_key}" : {
-      "post" : {
-        "description" : "Accept an invitation into a Chkk team. This does not require further authentication, as it only executes prior-created invitations.",
-        "operationId" : "AcceptInvitation",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "invite_key",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+  "servers": [
+    {
+      "description": "Prod",
+      "url": "https://api.chkk.dev/v1",
+      "x-server-name": "Production"
+    },
+    {
+      "description": "Prod AWS US-West-2",
+      "url": "https://api.us-west-2.aws.chkk.io/v1",
+      "x-server-name": "Production AWS US-West-2"
+    }
+  ],
+  "tags": [
+    {
+      "description": "APIs for management of subscriptions",
+      "name": "Subscription"
+    },
+    {
+      "description": "APIs used internally by Chkk components and are not meant for external callers",
+      "name": "Internal Endpoints"
+    },
+    {
+      "description": "APIs used to manage users, organizations and other identity concepts in Chkk",
+      "name": "Identity"
+    },
+    {
+      "description": "API used by the Chkk Agent or Chkk Operator that runs inside the K8s cluster",
+      "name": "Agent"
+    },
+    {
+      "description": "APIs used to manage LARs and their lifecycle",
+      "name": "LAR Status"
+    },
+    {
+      "description": "???",
+      "name": "Cluster"
+    },
+    {
+      "description": "???",
+      "name": "Scan"
+    },
+    {
+      "description": "APIs used to manage the integrations of Chkk with customer systems (e.g. ticketing)",
+      "name": "Integration"
+    },
+    {
+      "description": "APIs used by the systems integrated with Chkk - not for management of such integrations",
+      "name": "Integration Data"
+    },
+    {
+      "description": "APIs that are not to be used for new features and we are working to phase out",
+      "name": "Deprecated"
+    }
+  ],
+  "paths": {
+    "/accept/{invite_key}": {
+      "post": {
+        "description": "Accept an invitation into a Chkk team. This does not require further authentication, as it only executes prior-created invitations.",
+        "operationId": "acceptInvitation",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "invite_key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "tags" : [ "Identity Management" ]
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "AcceptInvitationRequest"
       }
     },
-    "/accounts/{account_slug}/subscriptions" : {
-      "get" : {
-        "description" : "Retrieve all the subscriptions associated with a Chkk account",
-        "operationId" : "ListSubscriptions",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to retrieve subscriptions",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListSubscriptionsResponse"
+    "/accounts/{account_slug}/subscriptions": {
+      "get": {
+        "description": "Retrieve all the subscriptions associated with a Chkk account",
+        "operationId": "getAll",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to retrieve subscriptions",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSubscriptionsResponse"
                 }
               }
             },
-            "description" : "Success Response"
+            "description": "Success Response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Subscription Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Subscription"
+        ],
+        "x-request-name": "ListSubscriptionsRequest"
       },
-      "post" : {
-        "description" : "Add a new subscription to the account",
-        "operationId" : "CreateSubscription",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to retrieve subscriptions",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateSubscriptionRequest"
+      "post": {
+        "description": "Add a new subscription to the account",
+        "operationId": "create",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to retrieve subscriptions",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSubscriptionRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/CreateSubscriptionResponse"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSubscriptionResponse"
                 }
               }
             },
-            "description" : "Success Response"
+            "description": "Success Response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Subscription Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Subscription"
+        ],
+        "x-request-name": "CreateSubscriptionRequest"
       }
     },
-    "/accounts/{account_slug}/subscriptions/{subscription_id}" : {
-      "get" : {
-        "description" : "Retrieve the details of a specific subscription",
-        "operationId" : "GetSubscription",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to retrieve a subscription",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/subscriptions/{subscription_id}": {
+      "get": {
+        "description": "Retrieve the details of a specific subscription",
+        "operationId": "get",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to retrieve a subscription",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The ID of the specific subscription to retrieve",
-          "explode" : false,
-          "in" : "path",
-          "name" : "subscription_id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ResolvedSubscription"
+          {
+            "description": "The ID of the specific subscription to retrieve",
+            "explode": false,
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedSubscription"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Subscription Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Subscription"
+        ],
+        "x-request-name": "GetSubscriptionRequest"
       },
-      "put" : {
-        "description" : "Update the properties of a specific subscription",
-        "operationId" : "UpdateSubscription",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to retrieve a subscription",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+      "put": {
+        "description": "Update the properties of a specific subscription",
+        "operationId": "update",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to retrieve a subscription",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The ID of the specific subscription to retrieve",
-          "explode" : false,
-          "in" : "path",
-          "name" : "subscription_id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateSubscriptionRequest"
+          {
+            "description": "The ID of the specific subscription to retrieve",
+            "explode": false,
+            "in": "path",
+            "name": "subscription_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSubscriptionRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Subscription Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Subscription"
+        ],
+        "x-request-name": "UpdateSubscriptionRequest"
       }
     },
-    "/accounts/{account_slug}/teams" : {
-      "get" : {
-        "description" : "List all teams in the given Chkk account",
-        "operationId" : "ListAccountTeams",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to manage teams",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/teams": {
+      "get": {
+        "description": "List all teams in the given Chkk account",
+        "operationId": "getAllTeams",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to manage teams",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The number of entries returned in a single call.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "pageSize",
-          "required" : false,
-          "schema" : {
-            "type" : "integer"
+          {
+            "description": "The number of entries returned in a single call.",
+            "explode": true,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The continuation token recieved in a prior call, for this call to return the next set of results",
-          "explode" : true,
-          "in" : "query",
-          "name" : "continuation_token",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListAccountTeamsResponse"
+          {
+            "description": "The continuation token recieved in a prior call, for this call to return the next set of results",
+            "explode": true,
+            "in": "query",
+            "name": "continuation_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAccountTeamsResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "ListAccountTeamsRequest"
       }
     },
-    "/accounts/{account_slug}/teams/{team_slug}" : {
-      "get" : {
-        "description" : "Get the details for a specific Chkk team in the Chkk account",
-        "operationId" : "GetAccountTeam",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to manage teams",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/teams/{team_slug}": {
+      "get": {
+        "description": "Get the details for a specific Chkk team in the Chkk account",
+        "operationId": "getAccount",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to manage teams",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The slug of the team to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "team_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Team"
+          {
+            "description": "The slug of the team to manage",
+            "explode": false,
+            "in": "path",
+            "name": "team_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Team"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "GetAccountTeamRequest"
       }
     },
-    "/accounts/{account_slug}/teams/{team_slug}/invitations" : {
-      "get" : {
-        "description" : "List the pending invitations to the Chkk team.",
-        "operationId" : "ListTeamInvitations",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to manage teams",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/teams/{team_slug}/invitations": {
+      "get": {
+        "description": "List the pending invitations to the Chkk team.",
+        "operationId": "listInvitations",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to manage teams",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The slug of the team to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "team_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+          {
+            "description": "The slug of the team to manage",
+            "explode": false,
+            "in": "path",
+            "name": "team_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The number of entries returned in a single call.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "pageSize",
-          "required" : false,
-          "schema" : {
-            "type" : "integer"
+          {
+            "description": "The number of entries returned in a single call.",
+            "explode": true,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The continuation token recieved in a prior call, for this call to return the next set of results",
-          "explode" : true,
-          "in" : "query",
-          "name" : "continuation_token",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListTeamInvitationsResponse"
+          {
+            "description": "The continuation token recieved in a prior call, for this call to return the next set of results",
+            "explode": true,
+            "in": "query",
+            "name": "continuation_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTeamInvitationsResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity Management"
+        ],
+        "x-request-name": "ListTeamInvitationsRequest"
       }
     },
-    "/accounts/{account_slug}/teams/{team_slug}/membership" : {
-      "post" : {
-        "description" : "Add a new member to an existing Chkk Team. This creates an invitation as well as an email notification to the person added to accept the invitation (beforehand they will not be a member)",
-        "operationId" : "AddTeamMember",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to manage teams",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/teams/{team_slug}/membership": {
+      "post": {
+        "description": "Add a new member to an existing Chkk Team. This creates an invitation as well as an email notification to the person added to accept the invitation (beforehand they will not be a member)",
+        "operationId": "addUser",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to manage teams",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The slug of the team to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "team_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AddTeamMemberRequest"
+          {
+            "description": "The slug of the team to manage",
+            "explode": false,
+            "in": "path",
+            "name": "team_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTeamMemberRequest"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "addteamMemberRequest"
       }
     },
-    "/accounts/{account_slug}/teams/{team_slug}/membership/{user_id}" : {
-      "delete" : {
-        "description" : "Remove a user from a Chkk team. The user won't be notified about this change.",
-        "operationId" : "DeleteTeamMember",
-        "parameters" : [ {
-          "description" : "The slug of the account for which to manage teams",
-          "explode" : false,
-          "in" : "path",
-          "name" : "account_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/accounts/{account_slug}/teams/{team_slug}/membership/{user_id}": {
+      "delete": {
+        "description": "Remove a user from a Chkk team. The user won't be notified about this change.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "description": "The slug of the account for which to manage teams",
+            "explode": false,
+            "in": "path",
+            "name": "account_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The slug of the team to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "team_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+          {
+            "description": "The slug of the team to manage",
+            "explode": false,
+            "in": "path",
+            "name": "team_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "description" : "The id of the user which to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "user_id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+          {
+            "description": "The id of the user which to manage",
+            "explode": false,
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "DeleteTeamMemberRequest"
       }
     },
-    "/chkk-analytics" : {
-      "post" : {
-        "description" : "Endpoint for the Amplitude tunnel used by the web apps to report analytics.",
-        "operationId" : "ProxyAmplitudeEvent",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AmplitudeAnalyticsReport"
+    "/chkk-analytics": {
+      "post": {
+        "description": "Endpoint for the Amplitude tunnel used by the web apps to report analytics.",
+        "operationId": "ProxyAmplitudeEvent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AmplitudeAnalyticsReport"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "object"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "tags" : [ "Internal Endpoints" ]
+        "tags": [
+          "Internal Endpoints"
+        ],
+        "x-request-name": "ProxyAmplitudeEventRequest"
       }
     },
-    "/cluster-contexts" : {
-      "post" : {
-        "description" : "???",
-        "operationId" : "SubmitClusterContext",
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/cluster-contexts": {
+      "post": {
+        "description": "???",
+        "operationId": "SubmitClusterContext",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Deprecated", "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Deprecated",
+          "Agent API"
+        ],
+        "x-request-name": "SubmitClusterContextRequest"
       }
     },
-    "/clusters" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "ListClusters",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListClustersResponse"
+    "/clusters": {
+      "get": {
+        "description": "???",
+        "operationId": "ListClusters",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClustersResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API", "Cluster Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent",
+          "Cluster"
+        ],
+        "x-request-name": "ListClustersRequest"
       },
-      "post" : {
-        "description" : "???",
-        "operationId" : "CreateCluster",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateClusterRequest"
+      "post": {
+        "description": "???",
+        "operationId": "CreateCluster",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClusterRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent API"
+        ],
+        "x-request-name": "CreateClusterRequest"
       }
     },
-    "/clusters/{clusterId}" : {
-      "delete" : {
-        "description" : "???",
-        "operationId" : "DeleteCluster",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+    "/clusters/{clusterId}": {
+      "delete": {
+        "description": "???",
+        "operationId": "DeleteCluster",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Cluster Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Cluster Management"
+        ],
+        "x-request-name": "DeleteClusterRequest"
       },
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetCluster",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+      "get": {
+        "description": "???",
+        "operationId": "get",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Cluster Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Cluster"
+        ],
+        "x-request-name": "GetClusterRequest"
       },
-      "put" : {
-        "description" : "???",
-        "operationId" : "UpdateCluster",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateClusterRequest"
+      "put": {
+        "description": "???",
+        "operationId": "update",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateClusterRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API", "Cluster Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent API",
+          "Cluster Management"
+        ],
+        "x-request-name": "UpdateClusterRequest"
       }
     },
-    "/clusters/{clusterId}/arsigs" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "ListClusterScansWithArsigs",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListClusterScansResponse"
+    "/clusters/{clusterId}/arsigs": {
+      "get": {
+        "description": "???",
+        "operationId": "getAll",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClusterScansResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Scan Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Scan Management"
+        ],
+        "x-request-name": "ListClusterScansWithArsigsRequest"
       }
     },
-    "/clusters/{clusterId}/deactivate" : {
-      "post" : {
-        "description" : "???",
-        "operationId" : "DeactivateCluster",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/DeactivateClusterRequest"
+    "/clusters/{clusterId}/deactivate": {
+      "post": {
+        "description": "???",
+        "operationId": "deactivate",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeactivateClusterRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Cluster Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Cluster Management"
+        ],
+        "x-request-name": "DeactivateClusterRequest"
       }
     },
-    "/clusters/{clusterId}/lars" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "ListClusterScansWithLars",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListClusterScansResponse"
+    "/clusters/{clusterId}/lars": {
+      "get": {
+        "description": "???",
+        "operationId": "ListClusterScansWithLars",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClusterScansResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Scan Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Scan Management"
+        ],
+        "x-request-name": "ListClusterScansWithLarsRequest"
       }
     },
-    "/clusters/{clusterId}/lars/status" : {
-      "get" : {
-        "description" : "List the status of all LARs for a cluster",
-        "operationId" : "ListLARsStatus",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListLARsStatusResponse"
+    "/clusters/{clusterId}/lars/status": {
+      "get": {
+        "description": "List the status of all LARs for a cluster",
+        "operationId": "getAllLARsStatus",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListLARsStatusResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "LAR Status Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "LAR Status Management"
+        ],
+        "x-request-name": "ListLARsStatusRequest"
       }
     },
-    "/clusters/{clusterId}/lars/status/{larId}" : {
-      "get" : {
-        "description" : "Get the status of a specific LAR",
-        "operationId" : "GetLARStatus",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/clusters/{clusterId}/lars/status/{larId}": {
+      "get": {
+        "description": "Get the status of a specific LAR",
+        "operationId": "get",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "explode" : false,
-          "in" : "path",
-          "name" : "larId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LARStatus"
+          {
+            "explode": false,
+            "in": "path",
+            "name": "larId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LARStatus"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "LAR Status Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "LAR Status"
+        ],
+        "x-request-name": "GetLARStatusRequest"
       }
     },
-    "/clusters/{clusterId}/lars/status/{larId}/ignore" : {
-      "post" : {
-        "description" : "Ignore a specific LAR",
-        "operationId" : "IgnoreLAR",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/clusters/{clusterId}/lars/status/{larId}/ignore": {
+      "post": {
+        "description": "Ignore a specific LAR",
+        "operationId": "ignore",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "explode" : false,
-          "in" : "path",
-          "name" : "larId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/IgnoreLARRequest"
+          {
+            "explode": false,
+            "in": "path",
+            "name": "larId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IgnoreLARRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LARStatus"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LARStatus"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "LAR Status Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "LAR Status"
+        ],
+        "x-request-name": "IgnoreLARRequest"
       }
     },
-    "/clusters/{clusterId}/lars/status/{larId}/acknowledge" : {
-      "post" : {
-        "description" : "Acknowledge a specific LAR",
-        "operationId" : "AcknowledgeLAR",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/clusters/{clusterId}/lars/status/{larId}/acknowledge": {
+      "post": {
+        "description": "Acknowledge a specific LAR",
+        "operationId": "acknowledge",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
           },
-          "style" : "simple"
-        }, {
-          "explode" : false,
-          "in" : "path",
-          "name" : "larId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/AcknowledgeLARRequest"
+          {
+            "explode": false,
+            "in": "path",
+            "name": "larId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcknowledgeLARRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LARStatus"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LARStatus"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "LAR Status Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "LAR Status"
+        ],
+        "x-request-name": "AcknowledgeLARRequest"
       }
     },
-    "/clusters/{clusterId}/rescan" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetClusterRescanState",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+    "/clusters/{clusterId}/rescan": {
+      "get": {
+        "description": "???",
+        "operationId": "getClusterRescanState",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "x-request-name": "GetClusterRescanStateRequest"
       },
-      "post" : {
-        "description" : "???",
-        "operationId" : "RescanCluster",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/RescanClusterRequest"
+      "post": {
+        "description": "???",
+        "operationId": "createRescanCluster",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RescanClusterRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "x-request-name": "RescanClusterRequest"
       }
     },
-    "/clusters/{clusterId}/scan" : {
-      "post" : {
-        "description" : "???",
-        "operationId" : "CreateClusterScan",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "clusterId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateClusterScanRequest"
+    "/clusters/{clusterId}/scan": {
+      "post": {
+        "description": "???",
+        "operationId": "createClusterScan",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "clusterId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateClusterScanRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Cluster"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "x-request-name": "CreateClusterScanRequest"
       }
     },
-    "/feedbacks" : {
-      "post" : {
-        "description" : "Endpoint for reporting feedback about Chkk of different nature - user sign-up requests, k8s questions or general feedback",
-        "operationId" : "SubmitFeedback",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SubmitFeedbackRequest"
+    "/feedbacks": {
+      "post": {
+        "description": "Endpoint for reporting feedback about Chkk of different nature - user sign-up requests, k8s questions or general feedback",
+        "operationId": "submitFeedback",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitFeedbackRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/SubmitFeedbackResponse"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitFeedbackResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "tags" : [ "Internal Endpoints" ]
+        "tags": [
+          "Internal"
+        ],
+        "x-request-name": "SubmitFeedbackRequest"
       }
     },
-    "/insights" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetInsights",
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/insights": {
+      "get": {
+        "description": "???",
+        "operationId": "getInsights",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Deprecated" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Deprecated"
+        ],
+        "x-request-name": "GetInsightsRequest"
       }
     },
-    "/insights/periods" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetInsightsPeriods",
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/insights/periods": {
+      "get": {
+        "description": "???",
+        "operationId": "GetInsightsPeriods",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Deprecated" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Deprecated"
+        ],
+        "x-request-name": "GetInsightsPeriodsRequest"
       }
     },
-    "/integrations" : {
-      "get" : {
-        "description" : "List the integrations configured in the Chkk account",
-        "operationId" : "ListIntegrations",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListIntegrationsResponse"
+    "/integrations": {
+      "get": {
+        "description": "List the integrations configured in the Chkk account",
+        "operationId": "getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListIntegrationsResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "ListIntegrationsRequest"
       },
-      "post" : {
-        "description" : "Create a new integration in the Chkk account",
-        "operationId" : "CreateIntegration",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateIntegrationRequest"
+      "post": {
+        "description": "Create a new integration in the Chkk account",
+        "operationId": "create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateIntegrationRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Integration"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "CreateIntegrationRequest"
       }
     },
-    "/integrations/prometheus/metrics" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetPrometheusMetricsScrape",
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/integrations/prometheus/metrics": {
+      "get": {
+        "description": "???",
+        "operationId": "getPrometheusMetricsScrape",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Data Plane" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration Data Plane"
+        ],
+        "x-request-name": "GetPrometheusMetricsScrapeRequest"
       }
     },
-    "/integrations/prometheus/status" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetPrometheusStatus",
-        "parameters" : [ {
-          "description" : "???",
-          "explode" : true,
-          "in" : "query",
-          "name" : "integration_name",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/integrations/prometheus/status": {
+      "get": {
+        "description": "???",
+        "operationId": "getPrometheusStatus",
+        "parameters": [
+          {
+            "description": "???",
+            "explode": true,
+            "in": "query",
+            "name": "integration_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "GetPrometheusStatusRequest"
       }
     },
-    "/integrations/{integrationId}" : {
-      "delete" : {
-        "description" : "Delete an existing integration from the Chkk account",
-        "operationId" : "DeleteIntegration",
-        "parameters" : [ {
-          "description" : "The ID of the integration to work with",
-          "explode" : false,
-          "in" : "path",
-          "name" : "integrationId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "Empty response"
+    "/integrations/{integrationId}": {
+      "delete": {
+        "description": "Delete an existing integration from the Chkk account",
+        "operationId": "delete",
+        "parameters": [
+          {
+            "description": "The ID of the integration to work with",
+            "explode": false,
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Empty response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "DeleteIntegrationRequest"
       },
-      "get" : {
-        "description" : "Get the details of an existing integration",
-        "operationId" : "GetIntegration",
-        "parameters" : [ {
-          "description" : "The ID of the integration to work with",
-          "explode" : false,
-          "in" : "path",
-          "name" : "integrationId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Integration"
+      "get": {
+        "description": "Get the details of an existing integration",
+        "operationId": "get",
+        "parameters": [
+          {
+            "description": "The ID of the integration to work with",
+            "explode": false,
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "GetIntegrationRequest"
       },
-      "put" : {
-        "description" : "Update an existing integration (e.g. with new status)",
-        "operationId" : "UpdateIntegration",
-        "parameters" : [ {
-          "description" : "The ID of the integration to work with",
-          "explode" : false,
-          "in" : "path",
-          "name" : "integrationId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateIntegrationRequest"
+      "put": {
+        "description": "Update an existing integration (e.g. with new status)",
+        "operationId": "update",
+        "parameters": [
+          {
+            "description": "The ID of the integration to work with",
+            "explode": false,
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateIntegrationRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Integration"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "UpdateIntegrationRequest"
       }
     },
-    "/integrations/{integrationId}/alert_manager_config" : {
-      "get" : {
-        "description" : "Retrieve the alert manager configuration snippet for the referenced integration",
-        "operationId" : "GetIntegrationAlertManagerConfig",
-        "parameters" : [ {
-          "description" : "The ID of the integration to work with",
-          "explode" : false,
-          "in" : "path",
-          "name" : "integrationId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "text/yaml" : { }
+    "/integrations/{integrationId}/alert_manager_config": {
+      "get": {
+        "description": "Retrieve the alert manager configuration snippet for the referenced integration",
+        "operationId": "getAlertManagerConfig",
+        "parameters": [
+          {
+            "description": "The ID of the integration to work with",
+            "explode": false,
+            "in": "path",
+            "name": "integrationId",
+            "required": true,
+            "schema": {
+              "type": "string"
             },
-            "description" : "success response"
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/yaml": {}
+            },
+            "description": "success response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "GetIntegrationAlertManagerConfigRequest"
       }
     },
-    "/kbas/{arsigId}" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetKba",
-        "parameters" : [ {
-          "explode" : false,
-          "in" : "path",
-          "name" : "arsigId",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/kbas/{arsigId}": {
+      "get": {
+        "description": "???",
+        "operationId": "getKba",
+        "parameters": [
+          {
+            "explode": false,
+            "in": "path",
+            "name": "arsigId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "GetKbaRequest"
       }
     },
-    "/larsoverview" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetLarOverview",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LarsOverviewResponse"
+    "/larsoverview": {
+      "get": {
+        "description": "???",
+        "operationId": "getOverview",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LarsOverviewResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "LAR Status Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "LAR Status"
+        ],
+        "x-request-name": "GetLarOverviewRequest"
       }
     },
-    "/login" : {
-      "post" : {
-        "description" : "Login the provided user, and make sure their core data structures are ready for use (e.g. that they have an account setup for them)",
-        "operationId" : "Login",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/LoginResponse"
+    "/login": {
+      "post": {
+        "description": "Login the provided user, and make sure their core data structures are ready for use (e.g. that they have an account setup for them)",
+        "operationId": "login",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "auth0TokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "auth0TokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "LoginRequest"
       }
     },
-    "/orgs/{org_slug}" : {
-      "get" : {
-        "description" : "Get the details for a specific organization",
-        "operationId" : "GetOrganization",
-        "parameters" : [ {
-          "description" : "The slug of the organization to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "org_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Organization"
+    "/orgs/{org_slug}": {
+      "get": {
+        "description": "Get the details for a specific organization",
+        "operationId": "getOrganization",
+        "parameters": [
+          {
+            "description": "The slug of the organization to manage",
+            "explode": false,
+            "in": "path",
+            "name": "org_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "GetOrganizationRequest"
       },
-      "put" : {
-        "description" : "Update the details of a specific organization (e.g. the displayed name)",
-        "operationId" : "UpdateOrganization",
-        "parameters" : [ {
-          "description" : "The slug of the organization to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "org_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateOrganizationRequest"
+      "put": {
+        "description": "Update the details of a specific organization (e.g. the displayed name)",
+        "operationId": "updateOrganization",
+        "parameters": [
+          {
+            "description": "The slug of the organization to manage",
+            "explode": false,
+            "in": "path",
+            "name": "org_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOrganizationRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Organization"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "UpdateOrganizationRequest"
       }
     },
-    "/orgs/{org_slug}/tokens" : {
-      "get" : {
-        "description" : "List the access tokens for the different accounts in the Chkk organization (for the calling user)",
-        "operationId" : "ListAccessTokens",
-        "parameters" : [ {
-          "description" : "The slug of the organization to manage",
-          "explode" : false,
-          "in" : "path",
-          "name" : "org_slug",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/orgs/{org_slug}/tokens": {
+      "get": {
+        "description": "List the access tokens for the different accounts in the Chkk organization (for the calling user)",
+        "operationId": "getAllAccessTokens",
+        "parameters": [
+          {
+            "description": "The slug of the organization to manage",
+            "explode": false,
+            "in": "path",
+            "name": "org_slug",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAccessTokensResponse"
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "security": [
+          {
+            "auth0TokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "ListAccessTokensRequest"
+      }
+    },
+    "/ingestion_scopes/{id}/token": {
+      "get": {
+        "description": "Get the ingestion token for the account",
+        "operationId": "getIngestionToken",
+        "parameters": [
+          {
+            "description": "The ID of the ingestion scope to get the token for",
+            "explode": false,
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetIngestionTokenResponse"
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity"
+        ],
+        "x-request-name": "GetIngestionTokenRequest"
+      }
+    },
+    "/quick-start": {
+      "get": {
+        "description": "???",
+        "operationId": "getQuickStartState",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuickStartResponse"
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "GetQuickStartStateRequest"
+      }
+    },
+    "/resources": {
+      "get": {
+        "description": "???",
+        "operationId": "getResource",
+        "parameters": [
+          {
+            "description": "the type of integration that the resource is retrieved for",
+            "explode": true,
+            "in": "query",
+            "name": "integration_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
           },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListAccessTokensResponse"
+          {
+            "description": "the name of the resource to be retrieved",
+            "explode": true,
+            "in": "query",
+            "name": "resource_name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
+          }
+        },
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Deprecated",
+          "Integration"
+        ],
+        "x-request-name": "GetResourceRequest"
+      }
+    },
+    "/scans": {
+      "get": {
+        "description": "???",
+        "operationId": "getAllScans",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListClusterScansResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "auth0TokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
-      }
-    },
-    "/ingestion_scopes/{id}/token" : {
-      "get" : {
-        "description" : "Get the ingestion token for the account",
-        "operationId" : "GetIngestionToken",
-        "parameters" : [ {
-          "description" : "The ID of the ingestion scope to get the token for",
-          "explode" : false,
-          "in" : "path",
-          "name" : "id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/GetIngestionTokenResponse"
-                }
-              }
-            },
-            "description" : "200 response"
+        "security": [
+          {
+            "accessTokenAuth": []
           }
-        },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management" ]
-      }
-    },
-    "/quick-start" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetQuickStartState",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/QuickStartResponse"
-                }
-              }
-            },
-            "description" : "200 response"
-          }
-        },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
-      }
-    },
-    "/resources" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "GetResource",
-        "parameters" : [ {
-          "description" : "the type of integration that the resource is retrieved for",
-          "explode" : true,
-          "in" : "query",
-          "name" : "integration_type",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        }, {
-          "description" : "the name of the resource to be retrieved",
-          "explode" : true,
-          "in" : "query",
-          "name" : "resource_name",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
-          }
-        },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Deprecated", "Integration Management" ]
-      }
-    },
-    "/scans" : {
-      "get" : {
-        "description" : "???",
-        "operationId" : "ListScans",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListClusterScansResponse"
-                }
-              }
-            },
-            "description" : "200 response"
-          }
-        },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        ],
+        "x-request-name": "ListScansRequest"
       },
-      "post" : {
-        "description" : "???",
-        "operationId" : "CreateScan",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateScanRequest"
+      "post": {
+        "description": "???",
+        "operationId": "createScan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScanRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/CreateScanResponse"
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateScanResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "CreateScanRequest"
       }
     },
-    "/sentry-proxy" : {
-      "post" : {
-        "description" : "Endpoint for the Sentry tunnel used by the web apps to report issues.\n\nSee https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option for more details.\n\nThe requests are in POST form, and consist of 3 lines with the first being a form of header containing the DSN of the report. The other lines report metadata as well as the stacktrace/breadcrumbs.\n",
-        "operationId" : "ProxySentryReport",
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+    "/sentry-proxy": {
+      "post": {
+        "description": "Endpoint for the Sentry tunnel used by the web apps to report issues.\n\nSee https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option for more details.\n\nThe requests are in POST form, and consist of 3 lines with the first being a form of header containing the DSN of the report. The other lines report metadata as well as the stacktrace/breadcrumbs.\n",
+        "operationId": "ProxySentryReport",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "tags" : [ "Internal Endpoints" ]
+        "tags": [
+          "Internal Endpoints"
+        ],
+        "x-request-name": "ProxySentryReportRequest"
       }
     },
-    "/tickets" : {
-      "post" : {
-        "description" : "???",
-        "operationId" : "CreateTicket",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/CreateTicketRequest"
+    "/tickets": {
+      "post": {
+        "description": "???",
+        "operationId": "createTicket",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTicketRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "content" : { },
-            "description" : "200 response"
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Integration Management" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Integration"
+        ],
+        "x-request-name": "CreateTicketRequest"
       }
     },
-    "/notifications/agent-status" : {
-      "post" : {
-        "description" : "Submit status notification for an agent",
-        "operationId" : "SubmitAgentStatusNotification",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/SubmitAgentStatusNotificationRequest"
+    "/notifications/agent-status": {
+      "post": {
+        "description": "Submit status notification for an agent",
+        "operationId": "submitAgentStatusNotification",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmitAgentStatusNotificationRequestBody"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "204" : {
-            "description" : "204 response"
+        "responses": {
+          "204": {
+            "description": "204 response"
           }
         },
-        "security" : [ { } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {}
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "x-request-name": "SubmitAgentStatusNotificationRequest"
       }
     },
-    "/notifications/agent-install" : {
-      "post" : {
-        "description" : "Submit an install notification for an agent",
-        "operationId" : "SubmitAgentInstallNotification",
-        "responses" : {
-          "204" : {
-            "description" : "204 response"
+    "/notifications/agent-install": {
+      "post": {
+        "description": "Submit an install notification for an agent",
+        "operationId": "submitAgentInstallNotification",
+        "responses": {
+          "204": {
+            "description": "204 response"
           }
         },
-        "security" : [ { } ],
-        "tags" : [ "Agent API" ]
+        "security": [
+          {}
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "x-request-name": "SubmitAgentInstallNotificationRequest"
       }
     },
-    "/users" : {
-      "get" : {
-        "description" : "Get details of the calling user",
-        "operationId" : "GetUsers",
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/GetUsersResponse"
+    "/users": {
+      "get": {
+        "description": "Get details of the calling user",
+        "operationId": "getUser",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetUsersResponse"
                 }
               }
             },
-            "description" : "200 response"
+            "description": "200 response"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ],
-        "tags" : [ "Identity Management", "Agent API" ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "tags": [
+          "Identity",
+          "Agent"
+        ],
+        "x-request-name": "GetUsersRequest"
       }
     },
-    "/availability_risks" : {
-      "get" : {
-        "description" : "List the AvailabilityRisks in the account, filtered by the query parameters",
-        "operationId" : "ListAvailabilityRisks",
-        "parameters" : [ {
-          "description" : "The filter can include one or multiple clauses separated by commas, e.g., severity:low, need_attention:true, category:defects",
-          "explode" : true,
-          "in" : "query",
-          "name" : "filter",
-          "required" : false,
-          "schema" : {
-            "items" : {
-              "type" : "string"
+    "/availability_risks": {
+      "get": {
+        "description": "List the AvailabilityRisks in the account, filtered by the query parameters",
+        "operationId": "getAllAvailabilityRisks",
+        "parameters": [
+          {
+            "description": "The filter can include one or multiple clauses separated by commas, e.g., severity:low, need_attention:true, category:defects",
+            "explode": true,
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
-            "type" : "array"
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The number of entries returned in a single call.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "pageSize",
-          "required" : false,
-          "schema" : {
-            "type" : "integer"
+          {
+            "description": "The number of entries returned in a single call.",
+            "explode": true,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The continuation token recieved in a prior call, for this call to return the next set of results",
-          "explode" : true,
-          "in" : "query",
-          "name" : "continuation_token",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "examples" : {
-                  "all_availability_risks" : {
-                    "description" : "list of availability risks",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "chkk-k8s-111",
-                        "title" : "k8s is fine",
-                        "category" : [ "defects", "bestPractices" ],
-                        "need_attention" : true,
-                        "availability_impact" : "very high impact",
-                        "status" : "detected",
-                        "severity" : "high",
-                        "labels" : { },
-                        "components" : {
-                          "addons" : [ "traefik", "coredns", "addon_3" ]
+          {
+            "description": "The continuation token recieved in a prior call, for this call to return the next set of results",
+            "explode": true,
+            "in": "query",
+            "name": "continuation_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "all_availability_risks": {
+                    "description": "list of availability risks",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "chkk-k8s-111",
+                          "title": "k8s is fine",
+                          "category": [
+                            "defects",
+                            "bestPractices"
+                          ],
+                          "need_attention": true,
+                          "availability_impact": "very high impact",
+                          "status": "detected",
+                          "severity": "high",
+                          "labels": {},
+                          "components": {
+                            "addons": [
+                              "traefik",
+                              "coredns",
+                              "addon_3"
+                            ]
+                          },
+                          "affected_resource_summary": {
+                            "clusters": 3,
+                            "namespaces": 2
+                          }
                         },
-                        "affected_resource_summary" : {
-                          "clusters" : 3,
-                          "namespaces" : 2
+                        {
+                          "id": "chkk-k8s-222",
+                          "title": "k8s is not fine",
+                          "category": [
+                            "deprecations"
+                          ],
+                          "need_attention": true,
+                          "availability_impact": "very high impact",
+                          "status": "resolved",
+                          "severity": "high",
+                          "labels": {},
+                          "components": {
+                            "addons": [
+                              "traefik",
+                              "coredns"
+                            ]
+                          },
+                          "affected_resource_summary": {
+                            "clusters": 3,
+                            "namespaces": 2
+                          }
                         }
-                      }, {
-                        "id" : "chkk-k8s-222",
-                        "title" : "k8s is not fine",
-                        "category" : [ "deprecations" ],
-                        "need_attention" : true,
-                        "availability_impact" : "very high impact",
-                        "status" : "resolved",
-                        "severity" : "high",
-                        "labels" : { },
-                        "components" : {
-                          "addons" : [ "traefik", "coredns" ]
-                        },
-                        "affected_resource_summary" : {
-                          "clusters" : 3,
-                          "namespaces" : 2
-                        }
-                      } ],
-                      "continuation_token" : "tok_1234"
+                      ],
+                      "continuation_token": "tok_1234"
                     }
                   },
-                  "defects_availability_risks" : {
-                    "description" : "list of availability risks",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "chkk-k8s-110",
-                        "title" : "k8s is fine",
-                        "category" : [ "defects", "bestPractices" ],
-                        "need_attention" : true,
-                        "availability_impact" : "very high impact",
-                        "status" : "detected",
-                        "severity" : "high",
-                        "labels" : { },
-                        "components" : {
-                          "addons" : [ "traefik" ]
+                  "defects_availability_risks": {
+                    "description": "list of availability risks",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "chkk-k8s-110",
+                          "title": "k8s is fine",
+                          "category": [
+                            "defects",
+                            "bestPractices"
+                          ],
+                          "need_attention": true,
+                          "availability_impact": "very high impact",
+                          "status": "detected",
+                          "severity": "high",
+                          "labels": {},
+                          "components": {
+                            "addons": [
+                              "traefik"
+                            ]
+                          },
+                          "affected_resource_summary": {
+                            "clusters": 3,
+                            "namespaces": 2
+                          }
                         },
-                        "affected_resource_summary" : {
-                          "clusters" : 3,
-                          "namespaces" : 2
+                        {
+                          "id": "chkk-k8s-220",
+                          "title": "k8s is not fine",
+                          "category": [
+                            "defects"
+                          ],
+                          "need_attention": true,
+                          "availability_impact": "very high impact",
+                          "status": "acknowledged",
+                          "severity": "high",
+                          "labels": {},
+                          "components": {
+                            "addons": [
+                              "coredns"
+                            ]
+                          },
+                          "affected_resource_summary": {
+                            "clusters": 3,
+                            "namespaces": 2
+                          }
                         }
-                      }, {
-                        "id" : "chkk-k8s-220",
-                        "title" : "k8s is not fine",
-                        "category" : [ "defects" ],
-                        "need_attention" : true,
-                        "availability_impact" : "very high impact",
-                        "status" : "acknowledged",
-                        "severity" : "high",
-                        "labels" : { },
-                        "components" : {
-                          "addons" : [ "coredns" ]
-                        },
-                        "affected_resource_summary" : {
-                          "clusters" : 3,
-                          "namespaces" : 2
-                        }
-                      } ],
-                      "continuation_token" : "tok_1234"
+                      ],
+                      "continuation_token": "tok_1234"
                     }
                   }
                 },
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListAvailabilityRisksResponse"
+                "schema": {
+                  "$ref": "#/components/schemas/ListAvailabilityRisksResponse"
                 }
               }
             },
-            "description" : "200 response with body"
+            "description": "200 response with body"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "ListAvailabilityRisksRequest"
       }
     },
-    "/availability_risks/summary" : {
-      "get" : {
-        "description" : "Return aggregate counts for the AvailabilityRisks in the account, filtered and grouped by the query parameters",
-        "operationId" : "GetAvailabilityRisksSummary",
-        "parameters" : [ {
-          "description" : "group_by can be repeated. Only category is supported value for the group_by clause.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "group_by",
-          "required" : true,
-          "schema" : {
-            "items" : {
-              "type" : "string"
+    "/availability_risks/summary": {
+      "get": {
+        "description": "Return aggregate counts for the AvailabilityRisks in the account, filtered and grouped by the query parameters",
+        "operationId": "getAvailabilityRisksSummary",
+        "parameters": [
+          {
+            "description": "group_by can be repeated. Only category is supported value for the group_by clause.",
+            "explode": true,
+            "in": "query",
+            "name": "group_by",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
-            "type" : "array"
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The filter can include one or multiple clauses separated by commas, e.g., severity:low, need_attention:true, category:defects",
-          "explode" : true,
-          "in" : "query",
-          "name" : "filter",
-          "required" : false,
-          "schema" : {
-            "items" : {
-              "type" : "string"
+          {
+            "description": "The filter can include one or multiple clauses separated by commas, e.g., severity:low, need_attention:true, category:defects",
+            "explode": true,
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             },
-            "type" : "array"
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "summary operation will apply filter and group_by clauses, and then count distinct values in the field specified for count parameter. Possible values are affected_resources, availability_risks",
-          "explode" : true,
-          "in" : "query",
-          "name" : "count",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "examples" : {
-                  "categories" : {
-                    "description" : "summary of availability risks, when group_by=category&filter=need_attention:true&count=availability_risk",
-                    "value" : {
-                      "data" : [ {
-                        "category" : "defects",
-                        "count" : 9
-                      }, {
-                        "category" : "misconfigurations",
-                        "count" : 1
-                      }, {
-                        "category" : "systemRequirements",
-                        "count" : 9
-                      }, {
-                        "category" : "deprecations",
-                        "count" : 9
-                      }, {
-                        "category" : "unsupportedVersions",
-                        "count" : 1
-                      }, {
-                        "category" : "versionIncompatibilities",
-                        "count" : 9
-                      }, {
-                        "category" : "bestPractices",
-                        "count" : 9
-                      } ]
+          {
+            "description": "summary operation will apply filter and group_by clauses, and then count distinct values in the field specified for count parameter. Possible values are affected_resources, availability_risks",
+            "explode": true,
+            "in": "query",
+            "name": "count",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "categories": {
+                    "description": "summary of availability risks, when group_by=category&filter=need_attention:true&count=availability_risk",
+                    "value": {
+                      "data": [
+                        {
+                          "category": "defects",
+                          "count": 9
+                        },
+                        {
+                          "category": "misconfigurations",
+                          "count": 1
+                        },
+                        {
+                          "category": "systemRequirements",
+                          "count": 9
+                        },
+                        {
+                          "category": "deprecations",
+                          "count": 9
+                        },
+                        {
+                          "category": "unsupportedVersions",
+                          "count": 1
+                        },
+                        {
+                          "category": "versionIncompatibilities",
+                          "count": 9
+                        },
+                        {
+                          "category": "bestPractices",
+                          "count": 9
+                        }
+                      ]
                     }
                   }
                 },
-                "schema" : {
-                  "$ref" : "#/components/schemas/AvailabilityRisksSummary"
+                "schema": {
+                  "$ref": "#/components/schemas/AvailabilityRisksSummary"
                 }
               }
             },
-            "description" : "200 response with body"
+            "description": "200 response with body"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "GetAvailabilityRisksSummaryRequest"
       }
     },
-    "/availability_risks/{availability_risk_id}/affected_resources" : {
-      "get" : {
-        "description" : "List the resourcs in this account affected by the AvailabilityRisk",
-        "operationId" : "GetAvailabilityRiskAffectedResource",
-        "parameters" : [ {
-          "description" : "availability_risk's id e.g. chkk-k8s-111",
-          "explode" : false,
-          "in" : "path",
-          "name" : "availability_risk_id",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          },
-          "style" : "simple"
-        }, {
-          "description" : "The filter can include one or multiple clauses separated by commas, e.g., type:cluster, cluster_id:k8scl_1234 etc.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "filter",
-          "required" : false,
-          "schema" : {
-            "items" : {
-              "type" : "string"
+    "/availability_risks/{availability_risk_id}/affected_resources": {
+      "get": {
+        "description": "List the resourcs in this account affected by the AvailabilityRisk",
+        "operationId": "getAvailabilityRiskAffectedResource",
+        "parameters": [
+          {
+            "description": "availability_risk's id e.g. chkk-k8s-111",
+            "explode": false,
+            "in": "path",
+            "name": "availability_risk_id",
+            "required": true,
+            "schema": {
+              "type": "string"
             },
-            "type" : "array"
+            "style": "simple"
           },
-          "style" : "form"
-        }, {
-          "description" : "The number of entries returned in a single call.",
-          "explode" : true,
-          "in" : "query",
-          "name" : "pageSize",
-          "required" : false,
-          "schema" : {
-            "type" : "integer"
+          {
+            "description": "The filter can include one or multiple clauses separated by commas, e.g., type:cluster, cluster_id:k8scl_1234 etc.",
+            "explode": true,
+            "in": "query",
+            "name": "filter",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
           },
-          "style" : "form"
-        }, {
-          "description" : "The continuation token recieved in a prior call, for this call to return the next set of results",
-          "explode" : true,
-          "in" : "query",
-          "name" : "continuation_token",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
+          {
+            "description": "The number of entries returned in a single call.",
+            "explode": true,
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "style": "form"
           },
-          "style" : "form"
-        } ],
-        "responses" : {
-          "200" : {
-            "content" : {
-              "application/json" : {
-                "examples" : {
-                  "clusters" : {
-                    "description" : "list of resources affectd by the availability risks filtered by filter=type:cluster",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "k8scl_x1",
-                        "name" : "websearch_cluster",
-                        "type" : "cluster",
-                        "metadata" : {
-                          "label" : "x1",
-                          "k8s_version" : "1.22",
-                          "region" : "us-west-1"
+          {
+            "description": "The continuation token recieved in a prior call, for this call to return the next set of results",
+            "explode": true,
+            "in": "query",
+            "name": "continuation_token",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "clusters": {
+                    "description": "list of resources affectd by the availability risks filtered by filter=type:cluster",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "k8scl_x1",
+                          "name": "websearch_cluster",
+                          "type": "cluster",
+                          "metadata": {
+                            "label": "x1",
+                            "k8s_version": "1.22",
+                            "region": "us-west-1"
+                          }
+                        },
+                        {
+                          "id": "k8scl_x2",
+                          "name": "prod",
+                          "type": "cluster",
+                          "metadata": {
+                            "label": "x1",
+                            "k8s_version": "1.22",
+                            "region": "us-west-1"
+                          }
+                        },
+                        {
+                          "id": "k8scl_x3",
+                          "name": "dev",
+                          "type": "cluster",
+                          "metadata": {
+                            "label": "x1",
+                            "k8s_version": "1.22",
+                            "region": "us-west-1"
+                          }
                         }
-                      }, {
-                        "id" : "k8scl_x2",
-                        "name" : "prod",
-                        "type" : "cluster",
-                        "metadata" : {
-                          "label" : "x1",
-                          "k8s_version" : "1.22",
-                          "region" : "us-west-1"
+                      ],
+                      "continuation_token": "tok_1234"
+                    }
+                  },
+                  "addons": {
+                    "description": "list of resources affectd by the availability risks filtered by filter=type:addon",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "coredns",
+                          "name": "coredns",
+                          "type": "addon",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "istio",
+                          "name": "istio",
+                          "type": "addon",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "prometheus",
+                          "name": "prometheus",
+                          "type": "addon",
+                          "metadata": {}
                         }
-                      }, {
-                        "id" : "k8scl_x3",
-                        "name" : "dev",
-                        "type" : "cluster",
-                        "metadata" : {
-                          "label" : "x1",
-                          "k8s_version" : "1.22",
-                          "region" : "us-west-1"
+                      ],
+                      "continuation_token": "tok_1234"
+                    }
+                  },
+                  "namespaces": {
+                    "description": "list of resources affectd by the availability risks filtered by filter=type:namespace",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "staging_ns",
+                          "name": "staging_ns",
+                          "type": "namespace",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "dev_ns",
+                          "name": "dev_ns",
+                          "type": "namespace",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "prod_ns",
+                          "name": "prod_ns",
+                          "type": "namespace",
+                          "metadata": {}
                         }
-                      } ],
-                      "continuation_token" : "tok_1234"
+                      ],
+                      "continuation_token": "tok_1234"
                     }
                   },
-                  "addons" : {
-                    "description" : "list of resources affectd by the availability risks filtered by filter=type:addon",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "coredns",
-                        "name" : "coredns",
-                        "type" : "addon",
-                        "metadata" : { }
-                      }, {
-                        "id" : "istio",
-                        "name" : "istio",
-                        "type" : "addon",
-                        "metadata" : { }
-                      }, {
-                        "id" : "prometheus",
-                        "name" : "prometheus",
-                        "type" : "addon",
-                        "metadata" : { }
-                      } ],
-                      "continuation_token" : "tok_1234"
+                  "addons in cluster": {
+                    "description": "list of resources affectd by the availability risks filtered by filter=type:addon&filter=cluster_id:k8scl_1234",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "coredns",
+                          "name": "coredns",
+                          "type": "addon",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "istio",
+                          "name": "istio",
+                          "type": "addon",
+                          "metadata": {}
+                        }
+                      ],
+                      "continuation_token": "tok_1234"
                     }
                   },
-                  "namespaces" : {
-                    "description" : "list of resources affectd by the availability risks filtered by filter=type:namespace",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "staging_ns",
-                        "name" : "staging_ns",
-                        "type" : "namespace",
-                        "metadata" : { }
-                      }, {
-                        "id" : "dev_ns",
-                        "name" : "dev_ns",
-                        "type" : "namespace",
-                        "metadata" : { }
-                      }, {
-                        "id" : "prod_ns",
-                        "name" : "prod_ns",
-                        "type" : "namespace",
-                        "metadata" : { }
-                      } ],
-                      "continuation_token" : "tok_1234"
-                    }
-                  },
-                  "addons in cluster" : {
-                    "description" : "list of resources affectd by the availability risks filtered by filter=type:addon&filter=cluster_id:k8scl_1234",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "coredns",
-                        "name" : "coredns",
-                        "type" : "addon",
-                        "metadata" : { }
-                      }, {
-                        "id" : "istio",
-                        "name" : "istio",
-                        "type" : "addon",
-                        "metadata" : { }
-                      } ],
-                      "continuation_token" : "tok_1234"
-                    }
-                  },
-                  "namespaces in cluster" : {
-                    "description" : "returns list of namespaces affectd by the availability risks filtered by filter=type:namespace&filter=cluster_id:k8scl_1234",
-                    "value" : {
-                      "data" : [ {
-                        "id" : "staging_ns",
-                        "name" : "staging_ns",
-                        "type" : "namespace",
-                        "metadata" : { }
-                      }, {
-                        "id" : "dev_ns",
-                        "name" : "dev_ns",
-                        "type" : "namespace",
-                        "metadata" : { }
-                      } ],
-                      "continuation_token" : "tok_1234"
+                  "namespaces in cluster": {
+                    "description": "returns list of namespaces affectd by the availability risks filtered by filter=type:namespace&filter=cluster_id:k8scl_1234",
+                    "value": {
+                      "data": [
+                        {
+                          "id": "staging_ns",
+                          "name": "staging_ns",
+                          "type": "namespace",
+                          "metadata": {}
+                        },
+                        {
+                          "id": "dev_ns",
+                          "name": "dev_ns",
+                          "type": "namespace",
+                          "metadata": {}
+                        }
+                      ],
+                      "continuation_token": "tok_1234"
                     }
                   }
                 },
-                "schema" : {
-                  "$ref" : "#/components/schemas/ListAffectedResourcesResponse"
+                "schema": {
+                  "$ref": "#/components/schemas/ListAffectedResourcesResponse"
                 }
               }
             },
-            "description" : "200 response with body"
+            "description": "200 response with body"
           }
         },
-        "security" : [ {
-          "accessTokenAuth" : [ ]
-        } ]
+        "security": [
+          {
+            "accessTokenAuth": []
+          }
+        ],
+        "x-request-name": "GetAvailabilityRiskAffectedResourceRequest"
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "ListSubscriptionsResponse" : {
-        "properties" : {
-          "account_id" : {
-            "type" : "string"
+  "components": {
+    "schemas": {
+      "ListSubscriptionsResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string"
           },
-          "subscriptions" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ResolvedSubscription"
+          "subscriptions": {
+            "items": {
+              "$ref": "#/components/schemas/ResolvedSubscription"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "total_entitlement" : {
-            "$ref" : "#/components/schemas/ResolvedEntitlement"
+          "total_entitlement": {
+            "$ref": "#/components/schemas/ResolvedEntitlement"
           }
         },
-        "required" : [ "account_id", "subscriptions", "total_entitlement" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "subscriptions",
+          "total_entitlement"
+        ],
+        "type": "object"
       },
-      "ResolvedSubscription" : {
-        "description" : "Details of a subscription including potentially external information (e.g. from cloud marketplaces)",
-        "properties" : {
-          "account_id" : {
-            "description" : "The Chkk account ID owning the subscription",
-            "type" : "string"
+      "ResolvedSubscription": {
+        "description": "Details of a subscription including potentially external information (e.g. from cloud marketplaces)",
+        "properties": {
+          "account_id": {
+            "description": "The Chkk account ID owning the subscription",
+            "type": "string"
           },
-          "subscription_id" : {
-            "description" : "The ID of the subscription itself",
-            "type" : "string"
+          "subscription_id": {
+            "description": "The ID of the subscription itself",
+            "type": "string"
           },
-          "name" : {
-            "description" : "Human readable description of the subscription, e.g. \"Chkk (Business Edition)\"",
-            "type" : "string"
+          "name": {
+            "description": "Human readable description of the subscription, e.g. \"Chkk (Business Edition)\"",
+            "type": "string"
           },
-          "type" : {
-            "$ref" : "#/components/schemas/SubscriptionType"
+          "type": {
+            "$ref": "#/components/schemas/SubscriptionType"
           },
-          "plan" : {
-            "$ref" : "#/components/schemas/SubscriptionPlan"
+          "plan": {
+            "$ref": "#/components/schemas/SubscriptionPlan"
           },
-          "entitlement" : {
-            "$ref" : "#/components/schemas/ResolvedEntitlement"
+          "entitlement": {
+            "$ref": "#/components/schemas/ResolvedEntitlement"
           }
         },
-        "required" : [ "account_id", "entitlement", "name", "plan", "subscription_id", "type" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "entitlement",
+          "name",
+          "plan",
+          "subscription_id",
+          "type"
+        ],
+        "type": "object"
       },
-      "SubscriptionType" : {
-        "description" : "The type of subscription aka how it is managed and charged",
-        "enum" : [ "CommunityEdition", "AWSMarketplace" ],
-        "type" : "string"
+      "SubscriptionType": {
+        "description": "The type of subscription aka how it is managed and charged",
+        "enum": [
+          "CommunityEdition",
+          "AWSMarketplace"
+        ],
+        "type": "string"
       },
-      "SubscriptionPlan" : {
-        "description" : "The kind of plan a subscription follows",
-        "enum" : [ "Community", "Business", "Enterprise" ],
-        "type" : "string"
+      "SubscriptionPlan": {
+        "description": "The kind of plan a subscription follows",
+        "enum": [
+          "Community",
+          "Business",
+          "Enterprise"
+        ],
+        "type": "string"
       },
-      "ResolvedEntitlement" : {
-        "description" : "Description of a resource entitlement. This follows the Chkk pricing structure - please refer there for details of the different dimensions",
-        "properties" : {
-          "node_count" : {
-            "description" : "Number of nodes across the infrastrcuture in this entitlement",
-            "type" : "integer"
+      "ResolvedEntitlement": {
+        "description": "Description of a resource entitlement. This follows the Chkk pricing structure - please refer there for details of the different dimensions",
+        "properties": {
+          "node_count": {
+            "description": "Number of nodes across the infrastrcuture in this entitlement",
+            "type": "integer"
           },
-          "small_clusters" : {
-            "deprecated" : true,
-            "description" : "Number of small clusters included in this entitlement",
-            "type" : "integer"
+          "small_clusters": {
+            "deprecated": true,
+            "description": "Number of small clusters included in this entitlement",
+            "type": "integer"
           },
-          "medium_clusters" : {
-            "deprecated" : true,
-            "description" : "Number of medium clusters included in this entitlement",
-            "type" : "integer"
+          "medium_clusters": {
+            "deprecated": true,
+            "description": "Number of medium clusters included in this entitlement",
+            "type": "integer"
           },
-          "large_clusters" : {
-            "deprecated" : true,
-            "description" : "Number of large clusters included in this entitlement",
-            "type" : "integer"
+          "large_clusters": {
+            "deprecated": true,
+            "description": "Number of large clusters included in this entitlement",
+            "type": "integer"
           }
         },
-        "required" : [ "node_count" ],
-        "type" : "object"
+        "required": [
+          "node_count"
+        ],
+        "type": "object"
       },
-      "CreateSubscriptionRequest" : {
-        "properties" : {
-          "subscription_type" : {
-            "$ref" : "#/components/schemas/SubscriptionType"
+      "CreateSubscriptionRequestBody": {
+        "properties": {
+          "subscription_type": {
+            "$ref": "#/components/schemas/SubscriptionType"
           },
-          "aws_registration_token" : {
-            "description" : "The registration token as vended by the AWS Marketplace",
-            "type" : "string"
+          "aws_registration_token": {
+            "description": "The registration token as vended by the AWS Marketplace",
+            "type": "string"
           }
         },
-        "required" : [ "subscription_type" ],
-        "type" : "object"
+        "required": [
+          "subscription_type"
+        ],
+        "type": "object"
       },
-      "CreateSubscriptionResponse" : {
-        "properties" : {
-          "account_id" : {
-            "type" : "string"
+      "CreateSubscriptionResponse": {
+        "properties": {
+          "account_id": {
+            "type": "string"
           },
-          "subscription_id" : {
-            "type" : "string"
+          "subscription_id": {
+            "type": "string"
           }
         },
-        "required" : [ "account_id", "subscription_id" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "subscription_id"
+        ],
+        "type": "object"
       },
-      "UpdateSubscriptionRequest" : {
-        "properties" : { },
-        "type" : "object"
+      "UpdateSubscriptionRequestBody": {
+        "properties": {},
+        "type": "object"
       },
-      "ListAccountTeamsResponse" : {
-        "description" : "A response to a request to list the Chkk Teams in a given Chkk Account",
-        "properties" : {
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
+      "ListAccountTeamsResponse": {
+        "description": "A response to a request to list the Chkk Teams in a given Chkk Account",
+        "properties": {
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
           },
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/Team"
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Team"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "continuation_token", "data" ],
-        "type" : "object"
+        "required": [
+          "continuation_token",
+          "data"
+        ],
+        "type": "object"
       },
-      "Team" : {
-        "description" : "A Chkk Team in a specific Chkk Account",
-        "properties" : {
-          "id" : {
-            "description" : "Team identifier",
-            "type" : "string"
+      "Team": {
+        "description": "A Chkk Team in a specific Chkk Account",
+        "properties": {
+          "id": {
+            "description": "Team identifier",
+            "type": "string"
           },
-          "account_id" : {
-            "description" : "Account ID",
-            "type" : "string"
+          "account_id": {
+            "description": "Account ID",
+            "type": "string"
           },
-          "slug" : {
-            "description" : "A human-readable, unique identifier for the Team",
-            "type" : "string"
+          "slug": {
+            "description": "A human-readable, unique identifier for the Team",
+            "type": "string"
           },
-          "name" : {
-            "description" : "Display name of the Team",
-            "type" : "string"
+          "name": {
+            "description": "Display name of the Team",
+            "type": "string"
           },
-          "created" : {
-            "description" : "Time at which the Team was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
+          "created": {
+            "description": "Time at which the Team was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "updated" : {
-            "description" : "Time at which the Team was updated. Measured in seconds since the Unix epoch",
-            "type" : "integer"
+          "updated": {
+            "description": "Time at which the Team was updated. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "members" : {
-            "description" : "Team members",
-            "items" : {
-              "$ref" : "#/components/schemas/TeamMember"
+          "members": {
+            "description": "Team members",
+            "items": {
+              "$ref": "#/components/schemas/TeamMember"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "account_id", "created", "id", "name", "slug" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "created",
+          "id",
+          "name",
+          "slug"
+        ],
+        "type": "object"
       },
-      "TeamMember" : {
-        "description" : "The details for a member of a Chkk Team",
-        "properties" : {
-          "user_id" : {
-            "description" : "The ID of the user that is a member of the Chkk Team",
-            "type" : "string"
+      "TeamMember": {
+        "description": "The details for a member of a Chkk Team",
+        "properties": {
+          "user_id": {
+            "description": "The ID of the user that is a member of the Chkk Team",
+            "type": "string"
           },
-          "user_email" : {
-            "description" : "The email address of the user that is a member of the Chkk Team",
-            "type" : "string"
+          "user_email": {
+            "description": "The email address of the user that is a member of the Chkk Team",
+            "type": "string"
           },
-          "user_name" : {
-            "description" : "The name of the user that is a member of the Chkk Team",
-            "type" : "string"
+          "user_name": {
+            "description": "The name of the user that is a member of the Chkk Team",
+            "type": "string"
           },
-          "user_picture" : {
-            "description" : "A URL to a picture or avatar of the user that is a member of the Chkk Team",
-            "type" : "string"
+          "user_picture": {
+            "description": "A URL to a picture or avatar of the user that is a member of the Chkk Team",
+            "type": "string"
           },
-          "date_added" : {
-            "description" : "Time at which the user became a member of the Chkk Team. Measured in seconds since the Unix epoch",
-            "type" : "integer"
+          "date_added": {
+            "description": "Time at which the user became a member of the Chkk Team. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/MembershipStatus"
+          "status": {
+            "$ref": "#/components/schemas/MembershipStatus"
           }
         },
-        "required" : [ "date_added", "status", "user_email", "user_id", "user_name" ],
-        "type" : "object"
+        "required": [
+          "date_added",
+          "status",
+          "user_email",
+          "user_id",
+          "user_name"
+        ],
+        "type": "object"
       },
-      "MembershipStatus" : {
-        "description" : "The status of a user's membership in a team. A user can be INVITED (before they accept the invitation) or ACTIVE (they are a member of the team)",
-        "enum" : [ "ACTIVE", "INACTIVE", "DEACTIVATED", "INVITED" ],
-        "type" : "string"
+      "MembershipStatus": {
+        "description": "The status of a user's membership in a team. A user can be INVITED (before they accept the invitation) or ACTIVE (they are a member of the team)",
+        "enum": [
+          "ACTIVE",
+          "INACTIVE",
+          "DEACTIVATED",
+          "INVITED"
+        ],
+        "type": "string"
       },
-      "ListTeamInvitationsResponse" : {
-        "description" : "Response for listing invitations in a team",
-        "properties" : {
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
+      "ListTeamInvitationsResponse": {
+        "description": "Response for listing invitations in a team",
+        "properties": {
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
           },
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/TeamInvitation"
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TeamInvitation"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "continuation_token", "data" ],
-        "type" : "object"
+        "required": [
+          "continuation_token",
+          "data"
+        ],
+        "type": "object"
       },
-      "AddTeamMemberRequest" : {
-        "description" : "The body of a request to add a user to a Chkk Team",
-        "properties" : {
-          "member_email" : {
-            "description" : "The email address of the user to add to the Chkk Team",
-            "type" : "string"
+      "AddTeamMemberRequest": {
+        "description": "The body of a request to add a user to a Chkk Team",
+        "properties": {
+          "member_email": {
+            "description": "The email address of the user to add to the Chkk Team",
+            "type": "string"
           }
         },
-        "required" : [ "member_email" ],
-        "type" : "object"
+        "required": [
+          "member_email"
+        ],
+        "type": "object"
       },
-      "AmplitudeAnalyticsReport" : {
-        "properties" : {
-          "logDetails" : {
-            "$ref" : "#/components/schemas/AmplitudeAnalyticsReportLogDetails"
+      "AmplitudeAnalyticsReport": {
+        "properties": {
+          "logDetails": {
+            "$ref": "#/components/schemas/AmplitudeAnalyticsReportLogDetails"
           }
         },
-        "required" : [ "logDetails" ],
-        "type" : "object"
+        "required": [
+          "logDetails"
+        ],
+        "type": "object"
       },
-      "ListClustersResponse" : {
-        "description" : "???",
-        "properties" : {
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/Cluster"
+      "ListClustersResponse": {
+        "description": "???",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Cluster"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "has_more" : {
-            "type" : "boolean"
+          "has_more": {
+            "type": "boolean"
           }
         },
-        "required" : [ "data", "has_more" ],
-        "type" : "object"
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "type": "object"
       },
-      "Cluster" : {
-        "description" : "???",
-        "properties" : {
-          "id" : {
-            "type" : "string"
+      "Cluster": {
+        "description": "???",
+        "properties": {
+          "id": {
+            "type": "string"
           },
-          "name" : {
-            "type" : "string"
+          "name": {
+            "type": "string"
           },
-          "internal_k8s_ref" : {
-            "type" : "string"
+          "internal_k8s_ref": {
+            "type": "string"
           },
-          "account_id" : {
-            "type" : "string"
+          "account_id": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/ClusterStatus"
+          "status": {
+            "$ref": "#/components/schemas/ClusterStatus"
           },
-          "production" : {
-            "description" : "whether this cluster should be considered to be part of production or not",
-            "type" : "boolean"
+          "production": {
+            "description": "whether this cluster should be considered to be part of production or not",
+            "type": "boolean"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "node_count" : {
-            "type" : "integer"
+          "node_count": {
+            "type": "integer"
           },
-          "managed_ng_count" : {
-            "type" : "integer"
+          "managed_ng_count": {
+            "type": "integer"
           },
-          "self_managed_ng_count" : {
-            "type" : "integer"
+          "self_managed_ng_count": {
+            "type": "integer"
           },
-          "container_runtimes" : {
-            "items" : {
-              "type" : "string"
+          "container_runtimes": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "labels" : {
-            "additionalProperties" : {
-              "type" : "string"
+          "labels": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InlineTypeString"
             },
-            "type" : "object"
+            "type": "object"
           },
-          "cloud_provider" : {
-            "$ref" : "#/components/schemas/KubernetesProvider"
+          "cloud_provider": {
+            "$ref": "#/components/schemas/KubernetesProvider"
           },
-          "chkk_metadata" : {
-            "$ref" : "#/components/schemas/ChkkAgent"
+          "chkk_metadata": {
+            "$ref": "#/components/schemas/ChkkAgent"
           },
-          "created" : {
-            "type" : "integer"
+          "created": {
+            "type": "integer"
           },
-          "updated" : {
-            "type" : "integer"
+          "updated": {
+            "type": "integer"
           },
-          "rescan" : {
-            "$ref" : "#/components/schemas/ClusterRescan"
+          "rescan": {
+            "$ref": "#/components/schemas/ClusterRescan"
           },
-          "eol_date" : {
-            "type" : "integer"
+          "eol_date": {
+            "type": "integer"
           },
-          "k8s_release_date" : {
-            "type" : "integer"
+          "k8s_release_date": {
+            "type": "integer"
           },
-          "k8s_provider_release" : {
-            "type" : "integer"
+          "k8s_provider_release": {
+            "type": "integer"
           }
         },
-        "required" : [ "account_id", "chkk_metadata", "cloud_provider", "container_runtimes", "created", "eol_date", "id", "internal_k8s_ref", "k8s_provider_release", "k8s_release_date", "labels", "managed_ng_count", "node_count", "region", "rescan", "self_managed_ng_count", "status", "version" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "chkk_metadata",
+          "cloud_provider",
+          "container_runtimes",
+          "created",
+          "eol_date",
+          "id",
+          "internal_k8s_ref",
+          "k8s_provider_release",
+          "k8s_release_date",
+          "labels",
+          "managed_ng_count",
+          "node_count",
+          "region",
+          "rescan",
+          "self_managed_ng_count",
+          "status",
+          "version"
+        ],
+        "type": "object"
       },
-      "ClusterStatus" : {
-        "description" : "???",
-        "enum" : [ "active", "deactivated" ],
-        "type" : "string"
+      "ClusterStatus": {
+        "description": "???",
+        "enum": [
+          "active",
+          "deactivated"
+        ],
+        "type": "string"
       },
-      "KubernetesProvider" : {
-        "description" : "???",
-        "enum" : [ "EKS", "KinD", "GKE", "AKS", "Minikube", "local" ],
-        "type" : "string"
+      "KubernetesProvider": {
+        "description": "???",
+        "enum": [
+          "EKS",
+          "KinD",
+          "GKE",
+          "AKS",
+          "Minikube",
+          "local"
+        ],
+        "type": "string"
       },
-      "ChkkAgent" : {
-        "description" : "???",
-        "properties" : {
-          "version" : {
-            "type" : "string"
+      "ChkkAgent": {
+        "description": "???",
+        "properties": {
+          "version": {
+            "type": "string"
           },
-          "git_commit" : {
-            "type" : "string"
+          "git_commit": {
+            "type": "string"
           },
-          "build_date" : {
-            "type" : "string"
+          "build_date": {
+            "type": "string"
           },
-          "config" : {
-            "additionalProperties" : {
-              "type" : "string"
+          "config": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InlineTypeString"
             },
-            "type" : "object"
+            "type": "object"
           },
-          "namespace" : {
-            "type" : "string"
+          "namespace": {
+            "type": "string"
           }
         },
-        "required" : [ "build_date", "config", "git_commit", "namespace", "version" ],
-        "type" : "object"
+        "required": [
+          "build_date",
+          "config",
+          "git_commit",
+          "namespace",
+          "version"
+        ],
+        "type": "object"
       },
-      "ClusterRescan" : {
-        "description" : "???",
-        "enum" : [ "in-progress", "completed", "pending" ],
-        "type" : "string"
+      "ClusterRescan": {
+        "description": "???",
+        "x-enum-names": [
+          {
+            "name": "in-progress",
+            "value": "in_progress"
+          },
+          {
+            "name": "completed",
+            "value": "completed"
+          },
+          {
+            "name": "pending",
+            "value": "pending"
+          }
+        ],
+        "type": "string"
       },
-      "CreateClusterRequest" : {
-        "description" : "???",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "CreateClusterRequestBody": {
+        "description": "???",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "internal_k8s_ref" : {
-            "type" : "string"
+          "internal_k8s_ref": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "production" : {
-            "description" : "whether this cluster should be considered to be part of production or not",
-            "type" : "boolean"
+          "production": {
+            "description": "whether this cluster should be considered to be part of production or not",
+            "type": "boolean"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "node_count" : {
-            "type" : "integer"
+          "node_count": {
+            "type": "integer"
           },
-          "managed_ng_count" : {
-            "type" : "integer"
+          "managed_ng_count": {
+            "type": "integer"
           },
-          "self_managed_ng_count" : {
-            "type" : "integer"
+          "self_managed_ng_count": {
+            "type": "integer"
           },
-          "container_runtimes" : {
-            "items" : {
-              "type" : "string"
+          "container_runtimes": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "labels" : {
-            "additionalProperties" : {
-              "type" : "string"
+          "labels": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ClusterRequestTypeString"
             },
-            "type" : "object"
+            "type": "object"
           },
-          "cloud_provider" : {
-            "$ref" : "#/components/schemas/KubernetesProvider"
+          "cloud_provider": {
+            "$ref": "#/components/schemas/KubernetesProvider"
           },
-          "chkk_metadata" : {
-            "$ref" : "#/components/schemas/ChkkAgent"
+          "chkk_metadata": {
+            "$ref": "#/components/schemas/ChkkAgent"
           }
         },
-        "required" : [ "chkk_metadata", "cloud_provider", "container_runtimes", "internal_k8s_ref", "labels", "managed_ng_count", "node_count", "region", "self_managed_ng_count", "version" ],
-        "type" : "object"
+        "required": [
+          "chkk_metadata",
+          "cloud_provider",
+          "container_runtimes",
+          "internal_k8s_ref",
+          "labels",
+          "managed_ng_count",
+          "node_count",
+          "region",
+          "self_managed_ng_count",
+          "version"
+        ],
+        "type": "object"
       },
-      "UpdateClusterRequest" : {
-        "description" : "???",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "ClusterRequestTypeString": {
+        "type": "string"
+      },
+      "UpdateClusterRequestBody": {
+        "description": "???",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "region" : {
-            "type" : "string"
+          "region": {
+            "type": "string"
           },
-          "production" : {
-            "description" : "whether this cluster should be considered to be part of production or not",
-            "type" : "boolean"
+          "production": {
+            "description": "whether this cluster should be considered to be part of production or not",
+            "type": "boolean"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "node_count" : {
-            "type" : "integer"
+          "node_count": {
+            "type": "integer"
           },
-          "managed_ng_count" : {
-            "type" : "integer"
+          "managed_ng_count": {
+            "type": "integer"
           },
-          "self_managed_ng_count" : {
-            "type" : "integer"
+          "self_managed_ng_count": {
+            "type": "integer"
           },
-          "container_runtimes" : {
-            "items" : {
-              "type" : "string"
+          "container_runtimes": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "labels" : {
-            "additionalProperties" : {
-              "type" : "string"
+          "labels": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InlineTypeString"
             },
-            "type" : "object"
+            "type": "object"
           },
-          "cloud_provider" : {
-            "$ref" : "#/components/schemas/KubernetesProvider"
+          "cloud_provider": {
+            "$ref": "#/components/schemas/KubernetesProvider"
           },
-          "chkk_metadata" : {
-            "$ref" : "#/components/schemas/ChkkAgent"
+          "chkk_metadata": {
+            "$ref": "#/components/schemas/ChkkAgent"
           }
         },
-        "type" : "object"
+        "type": "object"
       },
-      "ListClusterScansResponse" : {
-        "description" : "???",
-        "properties" : {
-          "has_more" : {
-            "type" : "boolean"
+      "ListClusterScansResponse": {
+        "description": "???",
+        "properties": {
+          "has_more": {
+            "type": "boolean"
           },
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterScan"
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterScan"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "data", "has_more" ],
-        "type" : "object"
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "type": "object"
       },
-      "ClusterScan" : {
-        "description" : "???",
-        "properties" : {
-          "id" : {
-            "type" : "string"
+      "InlineTypeString": {
+        "type": "string"
+      },
+      "ClusterScan": {
+        "description": "???",
+        "properties": {
+          "id": {
+            "type": "string"
           },
-          "cluster_id" : {
-            "type" : "string"
+          "cluster_id": {
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/ClusterScanStatus"
+          "status": {
+            "$ref": "#/components/schemas/ClusterScanStatus"
           },
-          "signatures" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterScannedSignature"
+          "signatures": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterScannedSignature"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "signature_count" : {
-            "type" : "integer"
+          "signature_count": {
+            "type": "integer"
           },
-          "lars" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterDetectedLar"
+          "lars": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterDetectedLar"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "lar_count" : {
-            "type" : "integer"
+          "lar_count": {
+            "type": "integer"
           },
-          "created" : {
-            "type" : "integer"
+          "created": {
+            "type": "integer"
           },
-          "updated" : {
-            "type" : "integer"
+          "updated": {
+            "type": "integer"
           }
         },
-        "required" : [ "cluster_id", "created", "id", "lar_count", "signature_count", "status" ],
-        "type" : "object"
+        "required": [
+          "cluster_id",
+          "created",
+          "id",
+          "lar_count",
+          "signature_count",
+          "status"
+        ],
+        "type": "object"
       },
-      "ClusterScanStatus" : {
-        "description" : "???",
-        "type" : "string"
+      "ClusterScanStatus": {
+        "description": "???",
+        "type": "string"
       },
-      "ClusterScannedSignature" : {
-        "description" : "???",
-        "properties" : {
-          "signature_id" : {
-            "type" : "string"
+      "ClusterScannedSignature": {
+        "description": "???",
+        "properties": {
+          "signature_id": {
+            "type": "string"
           },
-          "severity" : {
-            "$ref" : "#/components/schemas/Severity"
+          "severity": {
+            "$ref": "#/components/schemas/Severity"
           },
-          "availability_impact" : {
-            "type" : "string"
+          "availability_impact": {
+            "type": "string"
           },
-          "title" : {
-            "type" : "string"
+          "title": {
+            "type": "string"
           },
-          "url" : {
-            "type" : "string"
+          "url": {
+            "type": "string"
           },
-          "detected" : {
-            "type" : "boolean"
+          "detected": {
+            "type": "boolean"
           },
-          "labels" : {
-            "items" : {
-              "$ref" : "#/components/schemas/SignatureLabel"
+          "labels": {
+            "items": {
+              "$ref": "#/components/schemas/SignatureLabel"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "availability_impact", "detected", "labels", "severity", "signature_id", "title", "url" ],
-        "type" : "object"
+        "required": [
+          "availability_impact",
+          "detected",
+          "labels",
+          "severity",
+          "signature_id",
+          "title",
+          "url"
+        ],
+        "type": "object"
       },
-      "Severity" : {
-        "description" : "???",
-        "enum" : [ "Critical", "High", "Medium", "Low" ],
-        "type" : "string"
+      "Severity": {
+        "description": "???",
+        "enum": [
+          "Critical",
+          "High",
+          "Medium",
+          "Low"
+        ],
+        "type": "string"
       },
-      "SignatureLabel" : {
-        "additionalProperties" : {
-          "type" : "string"
+      "SignatureLabel": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/StringProperty"
         },
-        "type" : "object"
+        "type": "object"
       },
-      "ClusterDetectedLar" : {
-        "description" : "???",
-        "properties" : {
-          "signature_id" : {
-            "type" : "string"
+      "StringProperty": {
+        "type": "string"
+      },
+      "ClusterDetectedLar": {
+        "description": "???",
+        "properties": {
+          "signature_id": {
+            "type": "string"
           },
-          "severity" : {
-            "type" : "string"
+          "severity": {
+            "type": "string"
           },
-          "availability_impact" : {
-            "type" : "string"
+          "availability_impact": {
+            "type": "string"
           },
-          "title" : {
-            "type" : "string"
+          "title": {
+            "type": "string"
           },
-          "url" : {
-            "type" : "string"
+          "url": {
+            "type": "string"
           },
-          "need_attention" : {
-            "type" : "boolean"
+          "need_attention": {
+            "type": "boolean"
           },
-          "labels" : {
-            "items" : {
-              "$ref" : "#/components/schemas/SignatureLabel"
+          "labels": {
+            "items": {
+              "$ref": "#/components/schemas/SignatureLabel"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "remediations" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterDetectedLarRemidiation"
+          "remediations": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterDetectedLarRemidiation"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "trigger_conditions" : {
-            "$ref" : "#/components/schemas/ClusterDetectedLarTriggerConditions"
+          "trigger_conditions": {
+            "$ref": "#/components/schemas/ClusterDetectedLarTriggerConditions"
           },
-          "mitigations" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterDetectedLarMitigation"
+          "mitigations": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterDetectedLarMitigation"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "resources" : {
-            "items" : {
-              "$ref" : "#/components/schemas/ClusterDetectedLarAffectedResource"
+          "resources": {
+            "items": {
+              "$ref": "#/components/schemas/ClusterDetectedLarAffectedResource"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "availability_impact", "labels", "mitigations", "need_attention", "remediations", "resources", "severity", "signature_id", "title", "trigger_conditions", "url" ],
-        "type" : "object"
+        "required": [
+          "availability_impact",
+          "labels",
+          "mitigations",
+          "need_attention",
+          "remediations",
+          "resources",
+          "severity",
+          "signature_id",
+          "title",
+          "trigger_conditions",
+          "url"
+        ],
+        "type": "object"
       },
-      "DeactivateClusterRequest" : {
-        "description" : "???",
-        "properties" : {
-          "status" : {
-            "$ref" : "#/components/schemas/ClusterStatus"
+      "DeactivateClusterRequestBody": {
+        "description": "???",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ClusterStatus"
           }
         },
-        "required" : [ "status" ],
-        "type" : "object"
+        "required": [
+          "status"
+        ],
+        "type": "object"
       },
-      "ListLARsStatusResponse" : {
-        "properties" : {
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/LARStatus"
+      "ListLARsStatusResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LARStatus"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "data", "has_more" ],
-        "type" : "object"
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "type": "object"
       },
-      "LARStatus" : {
-        "properties" : {
-          "cluster_id" : {
-            "description" : "The ID of cluster that the LAR exists in",
-            "type" : "string"
+      "LARStatus": {
+        "properties": {
+          "cluster_id": {
+            "description": "The ID of cluster that the LAR exists in",
+            "type": "string"
           },
-          "lar_id" : {
-            "description" : "The ID of the LAR",
-            "type" : "string"
+          "lar_id": {
+            "description": "The ID of the LAR",
+            "type": "string"
           },
-          "jira_ticket" : {
-            "description" : "The JIRA ticket associated with the LAR",
-            "type" : "string"
+          "jira_ticket": {
+            "description": "The JIRA ticket associated with the LAR",
+            "type": "string"
           },
-          "issue_id" : {
-            "description" : "The ID of the issue associated with the LAR",
-            "type" : "string"
+          "issue_id": {
+            "description": "The ID of the issue associated with the LAR",
+            "type": "string"
           },
-          "ignore" : {
-            "description" : "Whether the LAR is ignored/unignored",
-            "type" : "boolean"
+          "ignore": {
+            "description": "Whether the LAR is ignored/unignored",
+            "type": "boolean"
           },
-          "acknowledge" : {
-            "description" : "Whether the LAR is acknowledged/unacknowledged",
-            "type" : "boolean"
+          "acknowledge": {
+            "description": "Whether the LAR is acknowledged/unacknowledged",
+            "type": "boolean"
           },
-          "severity" : {
-            "description" : "The severity of the LAR",
-            "type" : "string"
+          "severity": {
+            "description": "The severity of the LAR",
+            "type": "string"
           },
-          "user_id" : {
-            "description" : "The ID of the user that updated the LAR's status",
-            "type" : "string"
+          "user_id": {
+            "description": "The ID of the user that updated the LAR's status",
+            "type": "string"
           },
-          "created" : {
-            "description" : "The time the LAR was created",
-            "type" : "integer"
+          "created": {
+            "description": "The time the LAR was created",
+            "type": "integer"
           },
-          "updated" : {
-            "description" : "The time the LAR was last updated",
-            "type" : "integer"
+          "updated": {
+            "description": "The time the LAR was last updated",
+            "type": "integer"
           }
         },
-        "required" : [ "acknowledge", "cluster_id", "ignore", "lar_id" ],
-        "type" : "object"
+        "required": [
+          "acknowledge",
+          "cluster_id",
+          "ignore",
+          "lar_id"
+        ],
+        "type": "object"
       },
-      "IgnoreLARRequest" : {
-        "properties" : {
-          "ignore" : {
-            "description" : "Whether to ignore or unignore the LAR",
-            "type" : "boolean"
+      "IgnoreLARRequestBody": {
+        "properties": {
+          "ignore": {
+            "description": "Whether to ignore or unignore the LAR",
+            "type": "boolean"
           }
         },
-        "required" : [ "ignore" ],
-        "type" : "object"
+        "required": [
+          "ignore"
+        ],
+        "type": "object"
       },
-      "AcknowledgeLARRequest" : {
-        "properties" : {
-          "acknowledge" : {
-            "description" : "Whether to acknowledge or unacknowledge the LAR",
-            "type" : "boolean"
+      "AcknowledgeLARRequestBody": {
+        "properties": {
+          "acknowledge": {
+            "description": "Whether to acknowledge or unacknowledge the LAR",
+            "type": "boolean"
           }
         },
-        "required" : [ "acknowledge" ],
-        "type" : "object"
+        "required": [
+          "acknowledge"
+        ],
+        "type": "object"
       },
-      "RescanClusterRequest" : {
-        "description" : "???",
-        "properties" : {
-          "rescan_status" : {
-            "$ref" : "#/components/schemas/ClusterRescan"
+      "RescanClusterRequestBody": {
+        "description": "???",
+        "properties": {
+          "rescan_status": {
+            "$ref": "#/components/schemas/ClusterRescan"
           }
         },
-        "required" : [ "rescan_status" ],
-        "type" : "object"
+        "required": [
+          "rescan_status"
+        ],
+        "type": "object"
       },
-      "CreateClusterScanRequest" : {
-        "description" : "request from the collector to trigger the processing of a new scan",
-        "properties" : {
-          "cluster_id" : {
-            "type" : "string"
+      "CreateClusterScanRequestBody": {
+        "description": "request from the collector to trigger the processing of a new scan",
+        "properties": {
+          "cluster_id": {
+            "type": "string"
           },
-          "user_token" : {
-            "type" : "string"
+          "user_token": {
+            "type": "string"
           },
-          "rescan_status" : {
-            "type" : "string"
+          "rescan_status": {
+            "type": "string"
           }
         },
-        "required" : [ "cluster_id", "rescan_status", "user_token" ],
-        "type" : "object"
+        "required": [
+          "cluster_id",
+          "rescan_status",
+          "user_token"
+        ],
+        "type": "object"
       },
-      "SubmitFeedbackRequest" : {
-        "properties" : {
-          "title" : {
-            "description" : "The type of the feedback request. NewSignUpRequest, ReportAvailabilityRiskRequest and k8sExpertRequest have special meaning but callers might also specify their own values",
-            "type" : "string"
+      "SubmitFeedbackRequestBody": {
+        "properties": {
+          "title": {
+            "description": "The type of the feedback request. NewSignUpRequest, ReportAvailabilityRiskRequest and k8sExpertRequest have special meaning but callers might also specify their own values",
+            "type": "string"
           },
-          "details" : {
-            "description" : "The actual feedback contents. For structured feedback calls this might be JSON embedded into the string to convey more information.",
-            "type" : "string"
+          "details": {
+            "description": "The actual feedback contents. For structured feedback calls this might be JSON embedded into the string to convey more information.",
+            "type": "string"
           },
-          "user_email" : {
-            "description" : "The email address of the submitter of the feedback, for Chkk to get back to them.",
-            "type" : "string"
+          "user_email": {
+            "description": "The email address of the submitter of the feedback, for Chkk to get back to them.",
+            "type": "string"
           }
         },
-        "required" : [ "details", "title", "user_email" ],
-        "type" : "object"
+        "required": [
+          "details",
+          "title",
+          "user_email"
+        ],
+        "type": "object"
       },
-      "SubmitFeedbackResponse" : {
-        "properties" : {
-          "message" : {
-            "type" : "string"
+      "SubmitFeedbackResponse": {
+        "properties": {
+          "message": {
+            "type": "string"
           }
         },
-        "required" : [ "message" ],
-        "type" : "object"
+        "required": [
+          "message"
+        ],
+        "type": "object"
       },
-      "ListIntegrationsResponse" : {
-        "description" : "???",
-        "properties" : {
-          "data" : {
-            "description" : "???",
-            "items" : {
-              "$ref" : "#/components/schemas/Integration"
+      "ListIntegrationsResponse": {
+        "description": "???",
+        "properties": {
+          "data": {
+            "description": "???",
+            "items": {
+              "$ref": "#/components/schemas/Integration"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "has_more" : {
-            "description" : "???",
-            "type" : "boolean"
+          "has_more": {
+            "description": "???",
+            "type": "boolean"
           }
         },
-        "required" : [ "data", "has_more" ],
-        "type" : "object"
+        "required": [
+          "data",
+          "has_more"
+        ],
+        "type": "object"
       },
-      "CreateIntegrationRequest" : {
-        "description" : "???",
-        "properties" : {
-          "integration_name" : {
-            "description" : "???",
-            "type" : "string"
+      "CreateIntegrationRequestBody": {
+        "description": "???",
+        "properties": {
+          "integration_name": {
+            "description": "???",
+            "type": "string"
           },
-          "integration_type" : {
-            "$ref" : "#/components/schemas/IntegrationType"
+          "integration_type": {
+            "$ref": "#/components/schemas/IntegrationType"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/IntegrationStatus"
+          "status": {
+            "$ref": "#/components/schemas/IntegrationStatus"
           },
-          "slack_configuration" : {
-            "$ref" : "#/components/schemas/IntegrationSlackConfiguration"
+          "slack_configuration": {
+            "$ref": "#/components/schemas/IntegrationSlackConfiguration"
           },
-          "jira_configuration" : {
-            "$ref" : "#/components/schemas/IntegrationJiraConfiguration"
+          "jira_configuration": {
+            "$ref": "#/components/schemas/IntegrationJiraConfiguration"
           }
         },
-        "required" : [ "integration_name", "integration_type", "status" ],
-        "type" : "object"
+        "required": [
+          "integration_name",
+          "integration_type",
+          "status"
+        ],
+        "type": "object"
       },
-      "Integration" : {
-        "description" : "???",
-        "properties" : {
-          "account_id" : {
-            "type" : "string"
+      "Integration": {
+        "description": "???",
+        "properties": {
+          "account_id": {
+            "type": "string"
           },
-          "integration_id" : {
-            "description" : "???",
-            "type" : "string"
+          "integration_id": {
+            "description": "???",
+            "type": "string"
           },
-          "integration_name" : {
-            "description" : "???",
-            "type" : "string"
+          "integration_name": {
+            "description": "???",
+            "type": "string"
           },
-          "integration_type" : {
-            "$ref" : "#/components/schemas/IntegrationType"
+          "integration_type": {
+            "$ref": "#/components/schemas/IntegrationType"
           },
-          "integration_token" : {
-            "description" : "token used with some integrations to validate the correct association",
-            "type" : "string"
+          "integration_token": {
+            "description": "token used with some integrations to validate the correct association",
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/IntegrationStatus"
+          "status": {
+            "$ref": "#/components/schemas/IntegrationStatus"
           },
-          "resource_name" : {
-            "description" : "???",
-            "type" : "string"
+          "resource_name": {
+            "description": "???",
+            "type": "string"
           },
-          "slack_configuration" : {
-            "$ref" : "#/components/schemas/IntegrationSlackConfiguration"
+          "slack_configuration": {
+            "$ref": "#/components/schemas/IntegrationSlackConfiguration"
           },
-          "slack_app_configuration" : {
-            "$ref" : "#/components/schemas/IntegrationSlackAppConfiguration"
+          "slack_app_configuration": {
+            "$ref": "#/components/schemas/IntegrationSlackAppConfiguration"
           },
-          "jira_configuration" : {
-            "$ref" : "#/components/schemas/IntegrationJiraConfiguration"
+          "jira_configuration": {
+            "$ref": "#/components/schemas/IntegrationJiraConfiguration"
           },
-          "created" : {
-            "description" : "Time at which the Organization was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
+          "created": {
+            "description": "Time at which the Organization was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "updated" : {
-            "description" : "Time at which the Organization was updated. Measured in seconds since the Unix epoch",
-            "type" : "integer"
+          "updated": {
+            "description": "Time at which the Organization was updated. Measured in seconds since the Unix epoch",
+            "type": "integer"
           }
         },
-        "required" : [ "account_id", "created", "integration_id", "integration_name", "integration_type", "status" ],
-        "type" : "object"
+        "required": [
+          "account_id",
+          "created",
+          "integration_id",
+          "integration_name",
+          "integration_type",
+          "status"
+        ],
+        "type": "object"
       },
-      "IntegrationType" : {
-        "description" : "???",
-        "type" : "string"
+      "IntegrationType": {
+        "description": "???",
+        "type": "string"
       },
-      "IntegrationStatus" : {
-        "description" : "???",
-        "type" : "string"
+      "IntegrationStatus": {
+        "description": "???",
+        "type": "string"
       },
-      "IntegrationSlackConfiguration" : {
-        "description" : "???",
-        "properties" : {
-          "channels" : {
-            "items" : {
-              "$ref" : "#/components/schemas/IntegrationSlackChannel"
+      "IntegrationSlackConfiguration": {
+        "description": "???",
+        "properties": {
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationSlackChannel"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "channels" ],
-        "type" : "object"
+        "required": [
+          "channels"
+        ],
+        "type": "object"
       },
-      "IntegrationSlackChannel" : {
-        "description" : "???",
-        "properties" : {
-          "name" : {
-            "description" : "???",
-            "type" : "string"
+      "IntegrationSlackChannel": {
+        "description": "???",
+        "properties": {
+          "name": {
+            "description": "???",
+            "type": "string"
           },
-          "severity" : {
-            "description" : "???",
-            "type" : "string"
+          "severity": {
+            "description": "???",
+            "type": "string"
           },
-          "slack_api_url" : {
-            "description" : "???",
-            "type" : "string"
+          "slack_api_url": {
+            "description": "???",
+            "type": "string"
           }
         },
-        "required" : [ "slack_api_url" ],
-        "type" : "object"
+        "required": [
+          "slack_api_url"
+        ],
+        "type": "object"
       },
-      "IntegrationSlackAppConfiguration" : {
-        "description" : "???",
-        "properties" : {
-          "team" : {
-            "$ref" : "#/components/schemas/IntegrationSlackAppConfigurationTeam"
+      "IntegrationSlackAppConfiguration": {
+        "description": "???",
+        "properties": {
+          "team": {
+            "$ref": "#/components/schemas/IntegrationSlackAppConfigurationTeam"
           },
-          "enterprise" : {
-            "$ref" : "#/components/schemas/IntegrationSlackAppConfigurationEnterprise"
+          "enterprise": {
+            "$ref": "#/components/schemas/IntegrationSlackAppConfigurationEnterprise"
           },
-          "user" : {
-            "$ref" : "#/components/schemas/IntegrationSlackAppConfigurationUser"
+          "user": {
+            "$ref": "#/components/schemas/IntegrationSlackAppConfigurationUser"
           },
-          "isEnterpriseInstall" : {
-            "description" : "Whether the installation was performed on an enterprise org. Synthesized as `false` when not present",
-            "type" : "boolean"
+          "isEnterpriseInstall": {
+            "description": "Whether the installation was performed on an enterprise org. Synthesized as `false` when not present",
+            "type": "boolean"
           },
-          "enterpriseUrl" : {
-            "description" : "When the installation is an enterprise org install, the URL of the landing page for all workspaces in the org.",
-            "type" : "string"
+          "enterpriseUrl": {
+            "description": "When the installation is an enterprise org install, the URL of the landing page for all workspaces in the org.",
+            "type": "string"
           },
-          "bot" : {
-            "$ref" : "#/components/schemas/IntegrationSlackAppConfigurationBot"
+          "bot": {
+            "$ref": "#/components/schemas/IntegrationSlackAppConfigurationBot"
           }
         },
-        "required" : [ "user" ],
-        "type" : "object"
+        "required": [
+          "user"
+        ],
+        "type": "object"
       },
-      "IntegrationJiraConfiguration" : {
-        "description" : "???",
-        "properties" : {
-          "jira_user" : {
-            "description" : "???",
-            "type" : "string"
+      "IntegrationJiraConfiguration": {
+        "description": "???",
+        "properties": {
+          "jira_user": {
+            "description": "???",
+            "type": "string"
           },
-          "jira_token" : {
-            "description" : "???",
-            "type" : "string"
+          "jira_token": {
+            "description": "???",
+            "type": "string"
           },
-          "jira_url" : {
-            "description" : "???",
-            "type" : "string"
+          "jira_url": {
+            "description": "???",
+            "type": "string"
           },
-          "jira_project_key" : {
-            "description" : "???",
-            "type" : "string"
+          "jira_project_key": {
+            "description": "???",
+            "type": "string"
           }
         },
-        "required" : [ "jira_project_key", "jira_token", "jira_url", "jira_user" ],
-        "type" : "object"
+        "required": [
+          "jira_project_key",
+          "jira_token",
+          "jira_url",
+          "jira_user"
+        ],
+        "type": "object"
       },
-      "UpdateIntegrationRequest" : {
-        "description" : "???",
-        "properties" : {
-          "integration_name" : {
-            "description" : "???",
-            "type" : "string"
+      "UpdateIntegrationRequestBody": {
+        "description": "???",
+        "properties": {
+          "integration_name": {
+            "description": "???",
+            "type": "string"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/IntegrationStatus"
+          "status": {
+            "$ref": "#/components/schemas/IntegrationStatus"
           }
         },
-        "required" : [ "integration_name" ],
-        "type" : "object"
+        "required": [
+          "integration_name"
+        ],
+        "type": "object"
       },
-      "LarsOverviewResponse" : {
-        "description" : "???",
-        "properties" : {
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/LarsOverviewResponseItem"
+      "LarsOverviewResponse": {
+        "description": "???",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LarsOverviewResponseItem"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "data" ],
-        "type" : "object"
+        "required": [
+          "data"
+        ],
+        "type": "object"
       },
-      "LarsOverviewResponseItem" : {
-        "description" : "???",
-        "properties" : {
-          "period" : {
-            "type" : "string"
+      "LarsOverviewResponseItem": {
+        "description": "???",
+        "properties": {
+          "period": {
+            "type": "string"
           },
-          "lars" : {
-            "items" : {
-              "$ref" : "#/components/schemas/LarsOverviewResponseItemLar"
+          "lars": {
+            "items": {
+              "$ref": "#/components/schemas/LarsOverviewResponseItemLar"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "lars", "period" ],
-        "type" : "object"
+        "required": [
+          "lars",
+          "period"
+        ],
+        "type": "object"
       },
-      "LarsOverviewResponseItemLar" : {
-        "description" : "???",
-        "properties" : {
-          "signature_id" : {
-            "type" : "string"
+      "LarsOverviewResponseItemLar": {
+        "description": "???",
+        "properties": {
+          "signature_id": {
+            "type": "string"
           },
-          "severity" : {
-            "type" : "string"
+          "severity": {
+            "type": "string"
           },
-          "cluster_id" : {
-            "type" : "string"
+          "cluster_id": {
+            "type": "string"
           },
-          "title" : {
-            "type" : "string"
+          "title": {
+            "type": "string"
           },
-          "resolved" : {
-            "type" : "boolean"
+          "resolved": {
+            "type": "boolean"
           },
-          "acknowledged" : {
-            "type" : "boolean"
+          "acknowledged": {
+            "type": "boolean"
           },
-          "ignored" : {
-            "type" : "boolean"
+          "ignored": {
+            "type": "boolean"
           }
         },
-        "required" : [ "acknowledged", "cluster_id", "ignored", "resolved", "severity", "signature_id", "title" ],
-        "type" : "object"
+        "required": [
+          "acknowledged",
+          "cluster_id",
+          "ignored",
+          "resolved",
+          "severity",
+          "signature_id",
+          "title"
+        ],
+        "type": "object"
       },
-      "LoginResponse" : {
-        "description" : "Response to a login call, detailing the organizations available to a user",
-        "properties" : {
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
+      "LoginResponse": {
+        "description": "Response to a login call, detailing the organizations available to a user",
+        "properties": {
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
           },
-          "orgs" : {
-            "items" : {
-              "$ref" : "#/components/schemas/Organization"
+          "orgs": {
+            "items": {
+              "$ref": "#/components/schemas/Organization"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "access_tokens" : {
-            "additionalProperties" : {
-              "additionalProperties" : {
-                "type" : "string"
-              },
-              "description" : "A mapping from account slug (in the org) to the access token",
-              "type" : "object"
+          "access_tokens": {
+            "description": "For each org ID that you have access to, this contains the access tokens needed to access it",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AccountAccessToken"
+            }
+          }
+        },
+        "required": [
+          "continuation_token",
+          "orgs"
+        ],
+        "type": "object"
+      },
+      "AccountAccessToken": {
+        "type": "object",
+        "description": "A mapping from account slug (in the org) to the access token",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/InlineTypeString"
+        }
+      },
+      "Organization": {
+        "description": "A Chkk Organization, which owns a set of accounts. In most cases a Chkk Organization will map 1:1 to a customer, with different departments and use cases being modeled as different accounts.",
+        "properties": {
+          "id": {
+            "description": "Organization identifier",
+            "type": "string"
+          },
+          "slug": {
+            "description": "A human-readable, unique identifier for the Organization",
+            "type": "string"
+          },
+          "name": {
+            "description": "Display name of the Organization",
+            "type": "string"
+          },
+          "created": {
+            "description": "Time at which the Organization was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
+          },
+          "updated": {
+            "description": "Time at which the Organization was updated. Measured in seconds since the Unix epoch",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/OrganizationStatus"
+          },
+          "address": {
+            "description": "Company / Organization physical address",
+            "type": "string"
+          },
+          "logo_url": {
+            "description": "URL of the Organization logo",
+            "type": "string"
+          },
+          "website": {
+            "description": "Link to the Organization website",
+            "type": "string"
+          }
+        },
+        "required": [
+          "created",
+          "id",
+          "name",
+          "slug",
+          "status"
+        ],
+        "type": "object"
+      },
+      "OrganizationStatus": {
+        "description": "Status of the Organization: active, inactive, deleted etc",
+        "enum": [
+          "ACTIVE",
+          "INACTIVE",
+          "DEACTIVATED"
+        ],
+        "type": "string"
+      },
+      "UpdateOrganizationRequestBody": {
+        "description": "Update the details of a Chkk Organization",
+        "properties": {
+          "name": {
+            "description": "Display name of the Organization",
+            "type": "string"
+          },
+          "logo_url": {
+            "description": "URL of the Organization logo",
+            "type": "string"
+          },
+          "address": {
+            "description": "Company / Organization physical address",
+            "type": "string"
+          },
+          "website": {
+            "description": "Link to the Organization website",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ListAccessTokensResponse": {
+        "description": "A list of access tokens the caller has access to",
+        "properties": {
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AccessToken"
             },
-            "description" : "For each org ID that you have access to, this contains the access tokens needed to access it",
-            "type" : "object"
+            "type": "array"
           }
         },
-        "required" : [ "continuation_token", "orgs" ],
-        "type" : "object"
+        "required": [
+          "continuation_token",
+          "data"
+        ],
+        "type": "object"
       },
-      "Organization" : {
-        "description" : "A Chkk Organization, which owns a set of accounts. In most cases a Chkk Organization will map 1:1 to a customer, with different departments and use cases being modeled as different accounts.",
-        "properties" : {
-          "id" : {
-            "description" : "Organization identifier",
-            "type" : "string"
+      "GetIngestionTokenResponse": {
+        "description": "A JWT as used by the Chkk API for authentication",
+        "properties": {
+          "token": {
+            "description": "The actual token to be used in Authorization header",
+            "type": "string"
           },
-          "slug" : {
-            "description" : "A human-readable, unique identifier for the Organization",
-            "type" : "string"
+          "created": {
+            "description": "Time at which the jwt token was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "name" : {
-            "description" : "Display name of the Organization",
-            "type" : "string"
+          "expiration": {
+            "description": "Time at which the jwt token will expire. Measured in seconds since the Unix epoch",
+            "type": "integer"
           },
-          "created" : {
-            "description" : "Time at which the Organization was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "updated" : {
-            "description" : "Time at which the Organization was updated. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "status" : {
-            "$ref" : "#/components/schemas/OrganizationStatus"
-          },
-          "address" : {
-            "description" : "Company / Organization physical address",
-            "type" : "string"
-          },
-          "logo_url" : {
-            "description" : "URL of the Organization logo",
-            "type" : "string"
-          },
-          "website" : {
-            "description" : "Link to the Organization website",
-            "type" : "string"
+          "revoked": {
+            "description": "Time at which the jwt token was revoked. Measured in seconds since the Unix epoch",
+            "type": "integer"
           }
         },
-        "required" : [ "created", "id", "name", "slug", "status" ],
-        "type" : "object"
+        "required": [
+          "created",
+          "expiration",
+          "revoked",
+          "token"
+        ],
+        "type": "object"
       },
-      "OrganizationStatus" : {
-        "description" : "Status of the Organization: active, inactive, deleted etc",
-        "enum" : [ "ACTIVE", "INACTIVE", "DEACTIVATED" ],
-        "type" : "string"
-      },
-      "UpdateOrganizationRequest" : {
-        "description" : "Update the details of a Chkk Organization",
-        "properties" : {
-          "name" : {
-            "description" : "Display name of the Organization",
-            "type" : "string"
+      "QuickStartResponse": {
+        "description": "???",
+        "properties": {
+          "first_cluster": {
+            "$ref": "#/components/schemas/QuickStartResponseItem"
           },
-          "logo_url" : {
-            "description" : "URL of the Organization logo",
-            "type" : "string"
+          "invite_team_member": {
+            "$ref": "#/components/schemas/QuickStartResponseItem"
           },
-          "address" : {
-            "description" : "Company / Organization physical address",
-            "type" : "string"
-          },
-          "website" : {
-            "description" : "Link to the Organization website",
-            "type" : "string"
+          "join_slack": {
+            "$ref": "#/components/schemas/QuickStartResponseItem"
           }
         },
-        "type" : "object"
+        "required": [
+          "first_cluster",
+          "invite_team_member",
+          "join_slack"
+        ],
+        "type": "object"
       },
-      "ListAccessTokensResponse" : {
-        "description" : "A list of access tokens the caller has access to",
-        "properties" : {
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
+      "QuickStartResponseItem": {
+        "description": "???",
+        "properties": {
+          "status": {
+            "type": "boolean"
           },
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/AccessToken"
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "integer"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "user": {
+            "$ref": "#/components/schemas/QuickStartResponseItemUser"
+          }
+        },
+        "required": [
+          "description",
+          "priority",
+          "status",
+          "title"
+        ],
+        "type": "object"
+      },
+      "CreateScanRequestBody": {
+        "description": "Start a scan of the provided cluster",
+        "properties": {
+          "cluster_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "cluster_id"
+        ],
+        "type": "object"
+      },
+      "CreateScanResponse": {
+        "description": "???",
+        "properties": {
+          "id": {
+            "description": "The ID of the created Scan object",
+            "type": "string"
+          },
+          "status": {
+            "description": "The last status of the create Scan object",
+            "type": "string"
+          },
+          "created": {
+            "description": "The timestamp of the creation of the new Scan object",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "created",
+          "id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "CreateTicketRequestBody": {
+        "description": "???",
+        "properties": {
+          "summary": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "assignee_name": {
+            "type": "string"
+          },
+          "assignee_email": {
+            "type": "string"
+          },
+          "reporter_name": {
+            "type": "string"
+          },
+          "reporter_email": {
+            "type": "string"
+          },
+          "issue_type": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "lar_id": {
+            "type": "string"
+          },
+          "cluster_id": {
+            "type": "string"
+          },
+          "cluster_name": {
+            "type": "string"
+          },
+          "cluster_type": {
+            "type": "string"
+          },
+          "cluster_version": {
+            "type": "string"
+          },
+          "lar_details": {
+            "type": "string"
+          },
+          "lar_category": {
+            "type": "string"
+          },
+          "affected_resources": {
+            "items": {
+              "$ref": "#/components/schemas/CreateTicketRequestAffectedResource"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "continuation_token", "data" ],
-        "type" : "object"
+        "required": [
+          "affected_resources",
+          "assignee_email",
+          "assignee_name",
+          "cluster_id",
+          "cluster_name",
+          "cluster_type",
+          "cluster_version",
+          "description",
+          "issue_type",
+          "lar_category",
+          "lar_details",
+          "lar_id",
+          "priority",
+          "reporter_email",
+          "reporter_name",
+          "summary"
+        ],
+        "type": "object"
       },
-      "GetIngestionTokenResponse" : {
-        "description" : "A JWT as used by the Chkk API for authentication",
-        "properties" : {
-          "token" : {
-            "description" : "The actual token to be used in Authorization header",
-            "type" : "string"
+      "SubmitAgentStatusNotificationRequestBody": {
+        "properties": {
+          "resource_id": {
+            "description": "The ID of the resource that the notification is about.",
+            "type": "string"
           },
-          "created" : {
-            "description" : "Time at which the jwt token was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "expiration" : {
-            "description" : "Time at which the jwt token will expire. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "revoked" : {
-            "description" : "Time at which the jwt token was revoked. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          }
-        },
-        "required" : [ "created", "expiration", "revoked", "token" ],
-        "type" : "object"
-      },
-      "QuickStartResponse" : {
-        "description" : "???",
-        "properties" : {
-          "first_cluster" : {
-            "$ref" : "#/components/schemas/QuickStartResponseItem"
-          },
-          "invite_team_member" : {
-            "$ref" : "#/components/schemas/QuickStartResponseItem"
-          },
-          "join_slack" : {
-            "$ref" : "#/components/schemas/QuickStartResponseItem"
-          }
-        },
-        "required" : [ "first_cluster", "invite_team_member", "join_slack" ],
-        "type" : "object"
-      },
-      "QuickStartResponseItem" : {
-        "description" : "???",
-        "properties" : {
-          "status" : {
-            "type" : "boolean"
-          },
-          "title" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "priority" : {
-            "type" : "integer"
-          },
-          "created" : {
-            "type" : "integer"
-          },
-          "user" : {
-            "$ref" : "#/components/schemas/QuickStartResponseItemUser"
-          }
-        },
-        "required" : [ "description", "priority", "status", "title" ],
-        "type" : "object"
-      },
-      "CreateScanRequest" : {
-        "description" : "Start a scan of the provided cluster",
-        "properties" : {
-          "cluster_id" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "cluster_id" ],
-        "type" : "object"
-      },
-      "CreateScanResponse" : {
-        "description" : "???",
-        "properties" : {
-          "id" : {
-            "description" : "The ID of the created Scan object",
-            "type" : "string"
-          },
-          "status" : {
-            "description" : "The last status of the create Scan object",
-            "type" : "string"
-          },
-          "created" : {
-            "description" : "The timestamp of the creation of the new Scan object",
-            "type" : "integer"
-          }
-        },
-        "required" : [ "created", "id", "status" ],
-        "type" : "object"
-      },
-      "CreateTicketRequest" : {
-        "description" : "???",
-        "properties" : {
-          "summary" : {
-            "type" : "string"
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "assignee_name" : {
-            "type" : "string"
-          },
-          "assignee_email" : {
-            "type" : "string"
-          },
-          "reporter_name" : {
-            "type" : "string"
-          },
-          "reporter_email" : {
-            "type" : "string"
-          },
-          "issue_type" : {
-            "type" : "string"
-          },
-          "priority" : {
-            "type" : "string"
-          },
-          "lar_id" : {
-            "type" : "string"
-          },
-          "cluster_id" : {
-            "type" : "string"
-          },
-          "cluster_name" : {
-            "type" : "string"
-          },
-          "cluster_type" : {
-            "type" : "string"
-          },
-          "cluster_version" : {
-            "type" : "string"
-          },
-          "lar_details" : {
-            "type" : "string"
-          },
-          "lar_category" : {
-            "type" : "string"
-          },
-          "affected_resources" : {
-            "items" : {
-              "$ref" : "#/components/schemas/CreateTicketRequestAffectedResource"
+          "components": {
+            "description": "List of components reported as part of the notification.",
+            "items": {
+              "$ref": "#/components/schemas/AgentComponent"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "affected_resources", "assignee_email", "assignee_name", "cluster_id", "cluster_name", "cluster_type", "cluster_version", "description", "issue_type", "lar_category", "lar_details", "lar_id", "priority", "reporter_email", "reporter_name", "summary" ],
-        "type" : "object"
+        "required": [
+          "components",
+          "resource_id"
+        ],
+        "type": "object"
       },
-      "SubmitAgentStatusNotificationRequest" : {
-        "properties" : {
-          "resource_id" : {
-            "description" : "The ID of the resource that the notification is about.",
-            "type" : "string"
+      "ResourceStatus": {
+        "description": "The status of the resource.",
+        "enum": [
+          "Waiting",
+          "Terminated",
+          "Running",
+          "Unknown"
+        ],
+        "type": "string"
+      },
+      "AgentComponent": {
+        "description": "A component of the resource which submitted the notification.",
+        "properties": {
+          "name": {
+            "description": "The name of the component.",
+            "type": "string"
           },
-          "components" : {
-            "description" : "List of components reported as part of the notification.",
-            "items" : {
-              "$ref" : "#/components/schemas/AgentComponent"
+          "image": {
+            "description": "The image mounted on the component.",
+            "type": "string"
+          },
+          "image_type": {
+            "description": "Type of image the component uses. E.g OCI,AMI,etc",
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "reason": {
+            "description": "The reason for the state of the component.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "image",
+          "name",
+          "state"
+        ],
+        "type": "object"
+      },
+      "GetUsersResponse": {
+        "description": "Response to requesting details for the logged in identity",
+        "properties": {
+          "account_id": {
+            "description": "The ID of the Chkk Account of the current identity",
+            "type": "string"
+          },
+          "email": {
+            "description": "The email address of the user of the current identity",
+            "type": "string"
+          },
+          "name": {
+            "description": "the name of the user of the current identity",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "name"
+        ],
+        "type": "object"
+      },
+      "ListAvailabilityRisksResponse": {
+        "description": "Paginated list of Availability Risks ",
+        "properties": {
+          "data": {
+            "description": "List of Availability Risks",
+            "items": {
+              "$ref": "#/components/schemas/AvailabilityRisk"
             },
-            "type" : "array"
+            "type": "array"
+          },
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
           }
         },
-        "required" : [ "components", "resource_id" ],
-        "type" : "object"
+        "required": [
+          "continuation_token",
+          "data"
+        ],
+        "type": "object"
       },
-      "AgentComponent" : {
-        "description" : "A component of the resource which submitted the notification.",
-        "properties" : {
-          "name" : {
-            "description" : "The name of the component.",
-            "type" : "string"
+      "AvailabilityRisk": {
+        "description": "An Availability Risk is an instance of Availability Risk Signature which has failed in a cluster",
+        "properties": {
+          "id": {
+            "type": "string"
           },
-          "image" : {
-            "description" : "The image mounted on the component.",
-            "type" : "string"
+          "title": {
+            "type": "string"
           },
-          "image_type" : {
-            "description" : "Type of image the component uses. E.g OCI,AMI,etc",
-            "type" : "string"
-          },
-          "state" : {
-            "description" : "The status of the resource.",
-            "enum" : [ "Waiting", "Terminated", "Running", "Unknown" ],
-            "type" : "string"
-          },
-          "reason" : {
-            "description" : "The reason for the state of the component.",
-            "type" : "string"
-          }
-        },
-        "required" : [ "image", "name", "state" ],
-        "type" : "object"
-      },
-      "GetUsersResponse" : {
-        "description" : "Response to requesting details for the logged in identity",
-        "properties" : {
-          "account_id" : {
-            "description" : "The ID of the Chkk Account of the current identity",
-            "type" : "string"
-          },
-          "email" : {
-            "description" : "The email address of the user of the current identity",
-            "type" : "string"
-          },
-          "name" : {
-            "description" : "the name of the user of the current identity",
-            "type" : "string"
-          }
-        },
-        "required" : [ "email", "name" ],
-        "type" : "object"
-      },
-      "ListAvailabilityRisksResponse" : {
-        "description" : "Paginated list of Availability Risks ",
-        "properties" : {
-          "data" : {
-            "description" : "List of Availability Risks",
-            "items" : {
-              "$ref" : "#/components/schemas/AvailabilityRisk"
+          "category": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
           },
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
-          }
-        },
-        "required" : [ "continuation_token", "data" ],
-        "type" : "object"
-      },
-      "AvailabilityRisk" : {
-        "description" : "An Availability Risk is an instance of Availability Risk Signature which has failed in a cluster",
-        "properties" : {
-          "id" : {
-            "type" : "string"
+          "status": {
+            "$ref": "#/components/schemas/AvailabilityRiskStatus"
           },
-          "title" : {
-            "type" : "string"
+          "need_attention": {
+            "type": "boolean"
           },
-          "category" : {
-            "items" : {
-              "type" : "string"
+          "severity": {
+            "$ref": "#/components/schemas/AvailabilityRiskSeverity"
+          },
+          "availability_impact": {
+            "type": "string"
+          },
+          "labels": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StringArray"
             },
-            "type" : "array"
+            "type": "object"
           },
-          "status" : {
-            "$ref" : "#/components/schemas/AvailabilityRiskStatus"
+          "components": {
+            "$ref": "#/components/schemas/AvailabilityRiskComponents"
           },
-          "need_attention" : {
-            "type" : "boolean"
-          },
-          "severity" : {
-            "$ref" : "#/components/schemas/AvailabilityRiskSeverity"
-          },
-          "availability_impact" : {
-            "type" : "string"
-          },
-          "labels" : {
-            "additionalProperties" : {
-              "items" : {
-                "type" : "string"
-              },
-              "type" : "array"
+          "affected_resource_summary": {
+            "$ref": "#/components/schemas/AvailabilityRiskAffectedResourceSummary"
+          }
+        },
+        "required": [
+          "affected_resource_summary",
+          "availability_impact",
+          "components",
+          "id",
+          "labels",
+          "severity",
+          "title"
+        ],
+        "type": "object"
+      },
+      "StringArray": {
+        "items": {
+          "$ref": "#/components/schemas/StringProperty"
+        },
+        "type": "array"
+      },
+      "AvailabilityRiskStatus": {
+        "description": "different states of an Availability Risk",
+        "enum": [
+          "detected",
+          "resolved",
+          "acknowledged",
+          "ignored"
+        ],
+        "type": "string"
+      },
+      "AvailabilityRiskSeverity": {
+        "description": "severities of an Availability Risk",
+        "enum": [
+          "critical",
+          "high",
+          "medium",
+          "low"
+        ],
+        "type": "string"
+      },
+      "AvailabilityRisksSummary": {
+        "description": "Counts of Availability Risks or affected resources, given a group by clause and filters",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/SummaryEntry"
             },
-            "type" : "object"
-          },
-          "components" : {
-            "$ref" : "#/components/schemas/AvailabilityRiskComponents"
-          },
-          "affected_resource_summary" : {
-            "$ref" : "#/components/schemas/AvailabilityRiskAffectedResourceSummary"
+            "type": "array"
           }
         },
-        "required" : [ "affected_resource_summary", "availability_impact", "components", "id", "labels", "severity", "title" ],
-        "type" : "object"
+        "type": "object"
       },
-      "AvailabilityRiskStatus" : {
-        "description" : "different states of an Availability Risk",
-        "enum" : [ "detected", "resolved", "acknowledged", "ignored" ],
-        "type" : "string"
-      },
-      "AvailabilityRiskSeverity" : {
-        "description" : "severities of an Availability Risk",
-        "enum" : [ "critical", "high", "medium", "low" ],
-        "type" : "string"
-      },
-      "AvailabilityRisksSummary" : {
-        "description" : "Counts of Availability Risks or affected resources, given a group by clause and filters",
-        "properties" : {
-          "data" : {
-            "items" : {
-              "$ref" : "#/components/schemas/SummaryEntry"
+      "ListAffectedResourcesResponse": {
+        "description": "A response to a request to list the Resources in a given Chkk Account",
+        "properties": {
+          "availability_risk": {
+            "$ref": "#/components/schemas/AvailabilityRisk"
+          },
+          "data": {
+            "description": "List of Resource items",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
             },
-            "type" : "array"
+            "type": "array"
+          },
+          "continuation_token": {
+            "description": "a token to get the next page of results, or an empty string if no further results are available",
+            "type": "string"
           }
         },
-        "type" : "object"
+        "required": [
+          "continuation_token",
+          "data"
+        ],
+        "type": "object"
       },
-      "ListAffectedResourcesResponse" : {
-        "description" : "A response to a request to list the Resources in a given Chkk Account",
-        "properties" : {
-          "availability_risk" : {
-            "$ref" : "#/components/schemas/AvailabilityRisk"
+      "Resource": {
+        "description": "A resource is an object of any kind in the k8s cluster, e.g. cluster, namespace, addons etc.",
+        "properties": {
+          "id": {
+            "description": "resource id, e.g. k8scl_1234, ngsamespace_id, addon_id etc.",
+            "type": "string"
           },
-          "data" : {
-            "description" : "List of Resource items",
-            "items" : {
-              "$ref" : "#/components/schemas/Resource"
+          "name": {
+            "description": "resource's name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "e.g. cluster, namespace, addon",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StringProperty"
             },
-            "type" : "array"
-          },
-          "continuation_token" : {
-            "description" : "a token to get the next page of results, or an empty string if no further results are available",
-            "type" : "string"
+            "description": "resource's metadata, e.g., label, version, and region etc.",
+            "type": "object"
           }
         },
-        "required" : [ "continuation_token", "data" ],
-        "type" : "object"
+        "required": [
+          "id",
+          "metadata",
+          "name",
+          "type"
+        ],
+        "type": "object"
       },
-      "Resource" : {
-        "description" : "A resource is an object of any kind in the k8s cluster, e.g. cluster, namespace, addons etc.",
-        "properties" : {
-          "id" : {
-            "description" : "resource id, e.g. k8scl_1234, ngsamespace_id, addon_id etc.",
-            "type" : "string"
+      "TeamInvitationStatus": {
+        "description": "Status of the invite",
+        "enum": [
+          "ACCEPTED",
+          "PENDING"
+        ],
+        "type": "string"
+      },
+      "TeamInvitation": {
+        "description": "Details of an invitation for a user to join a Chkk Team",
+        "properties": {
+          "id": {
+            "description": "Invitation identifier",
+            "type": "string"
           },
-          "name" : {
-            "description" : "resource's name.",
-            "type" : "string"
+          "email": {
+            "description": "The user's email",
+            "type": "string"
           },
-          "type" : {
-            "description" : "e.g. cluster, namespace, addon",
-            "type" : "string"
+          "org_id": {
+            "description": "Organization ID",
+            "type": "string"
           },
-          "metadata" : {
-            "additionalProperties" : {
-              "type" : "string"
+          "invite_url": {
+            "description": "Invite URL",
+            "type": "string"
+          },
+          "invite_key": {
+            "description": "Invite key",
+            "type": "string"
+          },
+          "inviter": {
+            "description": "The person inviting",
+            "type": "string"
+          },
+          "created": {
+            "description": "Time at which the invite was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
+          },
+          "expiry": {
+            "description": "Time at which the invite will expire. Measured in seconds since the Unix epoch",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TeamInvitationStatus"
+          }
+        },
+        "required": [
+          "created",
+          "email",
+          "id",
+          "invite_key",
+          "invite_url",
+          "inviter",
+          "org_id",
+          "org_name",
+          "send_email",
+          "status"
+        ],
+        "type": "object"
+      },
+      "AccessToken": {
+        "description": "An access token as used by the Chkk API for authentication",
+        "properties": {
+          "access_token": {
+            "description": "The actual token to be used in Authorization header",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "The ID of the user represented by the access token",
+            "type": "string"
+          },
+          "org_id": {
+            "description": "The ID of the organization represented by the access token",
+            "type": "string"
+          },
+          "account_id": {
+            "description": "The ID of the account represented by the access token",
+            "type": "string"
+          },
+          "created": {
+            "description": "Time at which the access token was created. Measured in seconds since the Unix epoch",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "access_token",
+          "created"
+        ],
+        "type": "object"
+      },
+      "AmplitudeAnalyticsReportLogDetails": {
+        "additionalProperties": true,
+        "description": "Amplitude event as defined at https://github.com/amplitude/analytics-go/blob/main/amplitude/types/event.go#L3",
+        "properties": {
+          "event_type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_type"
+        ],
+        "title": "AmplitudeAnalyticsReportLogDetails",
+        "type": "object"
+      },
+      "ClusterDetectedLarRemidiation": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description",
+          "type"
+        ],
+        "title": "ClusterDetectedLarRemidiation",
+        "type": "object"
+      },
+      "ClusterDetectedLarTriggerConditions": {
+        "properties": {
+          "affected_versions": {
+            "items": {
+              "type": "string"
             },
-            "description" : "resource's metadata, e.g., label, version, and region etc.",
-            "type" : "object"
-          }
-        },
-        "required" : [ "id", "metadata", "name", "type" ],
-        "type" : "object"
-      },
-      "TeamInvitation" : {
-        "description" : "Details of an invitation for a user to join a Chkk Team",
-        "properties" : {
-          "id" : {
-            "description" : "Invitation identifier",
-            "type" : "string"
+            "type": "array"
           },
-          "email" : {
-            "description" : "The user's email",
-            "type" : "string"
-          },
-          "org_id" : {
-            "description" : "Organization ID",
-            "type" : "string"
-          },
-          "invite_url" : {
-            "description" : "Invite URL",
-            "type" : "string"
-          },
-          "invite_key" : {
-            "description" : "Invite key",
-            "type" : "string"
-          },
-          "inviter" : {
-            "description" : "The person inviting",
-            "type" : "string"
-          },
-          "created" : {
-            "description" : "Time at which the invite was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "expiry" : {
-            "description" : "Time at which the invite will expire. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          },
-          "status" : {
-            "description" : "Status of the invite",
-            "enum" : [ "ACCEPTED", "PENDING" ],
-            "type" : "string"
-          }
-        },
-        "required" : [ "created", "email", "id", "invite_key", "invite_url", "inviter", "org_id", "org_name", "send_email", "status" ],
-        "type" : "object"
-      },
-      "AccessToken" : {
-        "description" : "An access token as used by the Chkk API for authentication",
-        "properties" : {
-          "access_token" : {
-            "description" : "The actual token to be used in Authorization header",
-            "type" : "string"
-          },
-          "user_id" : {
-            "description" : "The ID of the user represented by the access token",
-            "type" : "string"
-          },
-          "org_id" : {
-            "description" : "The ID of the organization represented by the access token",
-            "type" : "string"
-          },
-          "account_id" : {
-            "description" : "The ID of the account represented by the access token",
-            "type" : "string"
-          },
-          "created" : {
-            "description" : "Time at which the access token was created. Measured in seconds since the Unix epoch",
-            "type" : "integer"
-          }
-        },
-        "required" : [ "access_token", "created" ],
-        "type" : "object"
-      },
-      "AmplitudeAnalyticsReportLogDetails" : {
-        "additionalProperties" : true,
-        "description" : "Amplitude event as defined at https://github.com/amplitude/analytics-go/blob/main/amplitude/types/event.go#L3",
-        "properties" : {
-          "event_type" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "event_type" ],
-        "title" : "AmplitudeAnalyticsReportLogDetails",
-        "type" : "object"
-      },
-      "ClusterDetectedLarRemidiation" : {
-        "properties" : {
-          "description" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "description", "type" ],
-        "title" : "ClusterDetectedLarRemidiation",
-        "type" : "object"
-      },
-      "ClusterDetectedLarTriggerConditions" : {
-        "properties" : {
-          "affected_versions" : {
-            "items" : {
-              "type" : "string"
+          "affected_images": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
+          }
+        },
+        "required": [
+          "affected_images",
+          "affected_versions"
+        ],
+        "title": "ClusterDetectedLarTriggerConditions",
+        "type": "object"
+      },
+      "ClusterDetectedLarMitigation": {
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "ClusterDetectedLarMitigation",
+        "type": "object"
+      },
+      "ClusterDetectedLarAffectedResource": {
+        "properties": {
+          "kind": {
+            "type": "string"
           },
-          "affected_images" : {
-            "items" : {
-              "type" : "string"
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name",
+          "namespace"
+        ],
+        "title": "ClusterDetectedLarAffectedResource",
+        "type": "object"
+      },
+      "IntegrationSlackAppConfigurationTeam": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "IntegrationSlackAppConfigurationTeam",
+        "type": "object"
+      },
+      "IntegrationSlackAppConfigurationEnterprise": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "IntegrationSlackAppConfigurationEnterprise",
+        "type": "object"
+      },
+      "IntegrationSlackAppConfigurationUser": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "IntegrationSlackAppConfigurationUser",
+        "type": "object"
+      },
+      "IntegrationSlackAppConfigurationBot": {
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "token",
+          "userId"
+        ],
+        "title": "IntegrationSlackAppConfigurationBot",
+        "type": "object"
+      },
+      "QuickStartResponseItemUser": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "name"
+        ],
+        "title": "QuickStartResponseItemUser",
+        "type": "object"
+      },
+      "CreateTicketRequestAffectedResource": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "name",
+          "namespace"
+        ],
+        "title": "CreateTicketRequestAffectedResource",
+        "type": "object"
+      },
+      "AvailabilityRiskComponents": {
+        "properties": {
+          "addons": {
+            "items": {
+              "type": "string"
             },
-            "type" : "array"
+            "type": "array"
           }
         },
-        "required" : [ "affected_images", "affected_versions" ],
-        "title" : "ClusterDetectedLarTriggerConditions",
-        "type" : "object"
+        "title": "AvailabilityRiskComponents",
+        "type": "object"
       },
-      "ClusterDetectedLarMitigation" : {
-        "properties" : {
-          "description" : {
-            "type" : "string"
+      "AvailabilityRiskAffectedResourceSummary": {
+        "properties": {
+          "clusters": {
+            "type": "integer"
+          },
+          "namespaces": {
+            "type": "integer"
+          },
+          "addons": {
+            "type": "integer"
           }
         },
-        "required" : [ "description" ],
-        "title" : "ClusterDetectedLarMitigation",
-        "type" : "object"
+        "title": "AvailabilityRiskAffectedResourceSummary",
+        "type": "object"
       },
-      "ClusterDetectedLarAffectedResource" : {
-        "properties" : {
-          "kind" : {
-            "type" : "string"
+      "SummaryEntry": {
+        "description": "examples: when counting Availability Risk with group_by only on category, each item will be like: {category:defects, count:9}",
+        "properties": {
+          "count": {
+            "type": "integer"
           },
-          "name" : {
-            "type" : "string"
-          },
-          "namespace" : {
-            "type" : "string"
+          "category": {
+            "type": "string"
           }
         },
-        "required" : [ "kind", "name", "namespace" ],
-        "title" : "ClusterDetectedLarAffectedResource",
-        "type" : "object"
-      },
-      "IntegrationSlackAppConfigurationTeam" : {
-        "properties" : {
-          "id" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "id" ],
-        "title" : "IntegrationSlackAppConfigurationTeam",
-        "type" : "object"
-      },
-      "IntegrationSlackAppConfigurationEnterprise" : {
-        "properties" : {
-          "id" : {
-            "type" : "string"
-          },
-          "name" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "id" ],
-        "title" : "IntegrationSlackAppConfigurationEnterprise",
-        "type" : "object"
-      },
-      "IntegrationSlackAppConfigurationUser" : {
-        "properties" : {
-          "id" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "id" ],
-        "title" : "IntegrationSlackAppConfigurationUser",
-        "type" : "object"
-      },
-      "IntegrationSlackAppConfigurationBot" : {
-        "properties" : {
-          "token" : {
-            "type" : "string"
-          },
-          "refreshToken" : {
-            "type" : "string"
-          },
-          "expiresAt" : {
-            "type" : "integer"
-          },
-          "id" : {
-            "type" : "string"
-          },
-          "userId" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "id", "token", "userId" ],
-        "title" : "IntegrationSlackAppConfigurationBot",
-        "type" : "object"
-      },
-      "QuickStartResponseItemUser" : {
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          },
-          "email" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "email", "name" ],
-        "title" : "QuickStartResponseItemUser",
-        "type" : "object"
-      },
-      "CreateTicketRequestAffectedResource" : {
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          },
-          "kind" : {
-            "type" : "string"
-          },
-          "namespace" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "kind", "name", "namespace" ],
-        "title" : "CreateTicketRequestAffectedResource",
-        "type" : "object"
-      },
-      "AvailabilityRiskComponents" : {
-        "properties" : {
-          "addons" : {
-            "items" : {
-              "type" : "string"
-            },
-            "type" : "array"
-          }
-        },
-        "title" : "AvailabilityRiskComponents",
-        "type" : "object"
-      },
-      "AvailabilityRiskAffectedResourceSummary" : {
-        "properties" : {
-          "clusters" : {
-            "type" : "integer"
-          },
-          "namespaces" : {
-            "type" : "integer"
-          },
-          "addons" : {
-            "type" : "integer"
-          }
-        },
-        "title" : "AvailabilityRiskAffectedResourceSummary",
-        "type" : "object"
-      },
-      "SummaryEntry" : {
-        "description" : "examples: when counting Availability Risk with group_by only on category, each item will be like: {category:defects, count:9}",
-        "properties" : {
-          "count" : {
-            "type" : "integer"
-          },
-          "category" : {
-            "type" : "string"
-          }
-        },
-        "required" : [ "count" ],
-        "title" : "SummaryEntry",
-        "type" : "object"
+        "required": [
+          "count"
+        ],
+        "title": "SummaryEntry",
+        "type": "object"
       }
     },
-    "securitySchemes" : {
-      "auth0TokenAuth" : {
-        "in" : "header",
-        "name" : "Authorization",
-        "type" : "apiKey"
+    "securitySchemes": {
+      "auth0TokenAuth": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
       },
-      "accessTokenAuth" : {
-        "in" : "header",
-        "name" : "Authorization",
-        "type" : "apiKey"
+      "accessTokenAuth": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
       }
     }
   }

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -1,29 +1,14 @@
-default-group: local
 groups:
-  local:
-    generators:
-      - name: fernapi/fern-typescript-sdk
-        version: 0.2.2
-        output:
-          location: local-file-system
-          path: ../../generated/typescript
-
   publish:
     generators:
       - name: fernapi/fern-typescript-sdk
         version: 0.2.2
         output:
           location: npm
-          package-name: '@fern-api/{company}'
+          package-name: '@fern-api/chkk'
           token: ${FERN_NPM_TOKEN}
+        config: 
+          namespaceExport: Chkk
         github:
-          repository: fern-{company}/{company}-node
-          
-      - name: fernapi/fern-postman
-        version: 0.0.40
-        output:
-          location: postman
-          api-key: ${FERN_POSTMAN_API_KEY}
-          workspace-id: ${FERN_POSTMAN_WORKSPACE_ID}
-        github:
-          repository: fern-{company}/{company}-postman
+          repository: fern-chkk/chkk-node
+        

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "{company}",
-  "version": "0.4.19"
+  "version": "0.4.33-rc7"
 }


### PR DESCRIPTION
To generate code using fern, the OpenAPI spec must pass fern check. Here's a summary of the changes we made to get to green:

- Added `x-request-name` to each endpoints. The fern generated SDKs abstract away http concepts like path parameters, query parameters, headers, request body by providing one wrapper type for the request, however in order to do that our generators need to know what the request name should be.

- Updated `operationId` on each endpoint. The operationId is used for code generation in the SDK when generating function names for each endpoint.

- Refactored a couple inlined types

- Added x-enum-names which provides a code-friendly name for enum value. 